### PR TITLE
Fix ffmpeg build for FreeBSD/amd64.

### DIFF
--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -16,7 +16,7 @@
 #   Under 10.6, builds Universal Binaries for i386/x86_64 Perl 5.10.0
 #   Under 10.7, builds for x86_64 Perl 5.12.3 (Lion does not support 32-bit CPUs)
 # FreeBSD 7.2 (Perl 5.8.9)
-# FreeBSD 8.2 (Perl 5.12.4)
+# FreeBSD 8.X,9.X (Perl 5.12.4)
 #
 # Perl 5.12.4/5.14.1 note:
 #   You should build 5.12.4 using perlbrew and the following command. GCC's stack protector must be disabled
@@ -1441,6 +1441,10 @@ function build_ffmpeg {
     # XXX test --arch options on Linux
     if [ $ARCH = "x86_64-linux-thread-multi" ]; then
         FFOPTS="$FFOPTS --disable-mmx"
+    fi
+    # FreeBSD amd64 needs arch option
+    if [ $ARCH = "amd64-freebsd" ]; then
+	FFOPTS="$FFOPTS --arch=x64"
     fi
     
     if [ $OS = "Darwin" ]; then


### PR DESCRIPTION
We need to pass "--arch=x64" to the ffmpeg config when we're using the amd64 flavour of FreeBSD. 
