### PR TITLE
Fix libjpeg-turbo OSX 10.9 test (fails on non-OSX OSes).

### DIFF
--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -1366,7 +1366,7 @@ function build_libjpeg {
     
     # build libjpeg-turbo on x86 platforms
     # skip on 10.9 until we've been able to build nasm from macports
-    if [ $OS = "Darwin" -a $OSX_VER != "10.5" ]; then
+    if [ "$OS" = Darwin -a "$OSX_VER" != "10.5" ]; then
         # Build i386/x86_64 versions of turbo
         tar zxvf libjpeg-turbo-1.1.1.tar.gz
         cd libjpeg-turbo-1.1.1
@@ -1409,7 +1409,7 @@ function build_libjpeg {
         cp -f libjpeg.a $BUILD/lib/libjpeg.a
         cd ..
     
-    elif [ $OS = "Darwin" -a $OSX_VER = "10.5" ]; then
+    elif [ "$OS" = Darwin -a "$OSX_VER" = "10.5" ]; then
         # combine i386 turbo with ppc libjpeg
         
         # build i386 turbo


### PR DESCRIPTION
This fixes a recently-introduced bug in the buildme.sh script which causes it to fail on non-OSX machines. The problem is that $OSX_VER can be empty, which causes test to fail.

I had to run this because I recently upgraded my x86_64 Linux box from Fedora 17 to Fedora 19 and needed x86_64 versions for the DSOs for Perl 5.16.
