### PR TITLE
perl 5.22 support required for fedora 23

### DIFF
--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -694,7 +694,7 @@ function build {
         JSON::XS)
             build_module common-sense-2.0
             
-            if [ "$PERL_518" -o "$PERL_520" ]; then
+            if [ "$PERL_518" -o "$PERL_520" -o "$PERL_522" ]; then
                 build_module JSON-XS-2.34
                 cp -pR $PERL_BASE/lib/perl5/$ARCH/JSON $PERL_ARCH/
             else

--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -292,6 +292,19 @@ if [ $PERL_520 ]; then
     PERL_ARCH=$BUILD/arch/5.20
 fi
 
+# Path to Perl 5.22
+if [ -x "/usr/bin/perl5.22.1" ]; then
+    PERL_522=/usr/bin/perl5.22.1
+fi
+
+if [ $PERL_522 ]; then
+    echo "Building with Perl 5.22 at $PERL_522"
+    PERL_BIN=$PERL_522
+    # Install dir for 5.22
+    PERL_BASE=$BUILD/5.22
+    PERL_ARCH=$BUILD/arch/5.22
+fi
+
 # try to use default perl version
 if [ "$PERL_BIN" = "" ]; then
     PERL_BIN=`which perl`
@@ -318,6 +331,9 @@ if [ "$PERL_BIN" = "" ]; then
         ;;
     "5.20")
         PERL_520=$PERL_BIN
+        ;;
+    "5.22")
+        PERL_522=$PERL_BIN
         ;;
     *)
         echo "Failed to find supported Perl version for '$PERL_BIN'"
@@ -484,7 +500,7 @@ function build {
             ;;
         
         Class::XSAccessor)
-            if [ "$PERL_516" -o "$PERL_518" -o "$PERL_520" ]; then
+            if [ "$PERL_516" -o "$PERL_518" -o "$PERL_520" -o "$PERL_522" ]; then
                 build_module Class-XSAccessor-1.18
                 cp -pR $PERL_BASE/lib/perl5/$ARCH/Class $PERL_ARCH/
             else
@@ -500,7 +516,7 @@ function build {
             ;;
         
         DBI)
-            if [ "$PERL_518" -o "$PERL_520" ]; then
+            if [ "$PERL_518" -o "$PERL_520" -o "$PERL_522" ]; then
                 build_module DBI-1.628
                 cp -p $PERL_BASE/lib/perl5/$ARCH/DBI.pm $PERL_ARCH/
                 cp -pR $PERL_BASE/lib/perl5/$ARCH/DBI $PERL_ARCH/
@@ -510,7 +526,7 @@ function build {
             ;;
         
         DBD::SQLite)
-            if [ "$PERL_518" -o "$PERL_520" ]; then
+            if [ "$PERL_518" -o "$PERL_520" -o "$PERL_522" ]; then
                 build_module DBI-1.628 "" 0
             else
                 build_module DBI-1.616 "" 0
@@ -596,7 +612,7 @@ function build {
                 rm -rf DBD-SQLite-1.34_01
             else
                 cd ..
-                if [ "$PERL_516" -o "$PERL_518" -o "$PERL_520" ]; then
+                if [ "$PERL_516" -o "$PERL_518" -o "$PERL_520" -o "$PERL_522" ]; then
                    build_module DBD-SQLite-1.34_01 "" 0
                 fi
                 build_module DBD-SQLite-1.34_01
@@ -708,7 +724,7 @@ function build {
             ;;
         
         YAML::LibYAML)
-            if [ "$PERL_516" -o "$PERL_518" -o "$PERL_520" ]; then
+            if [ "$PERL_516" -o "$PERL_518" -o "$PERL_520" -o "$PERL_522" ]; then
                 build_module YAML-LibYAML-0.35 "" 0
             else
                 build_module YAML-LibYAML-0.35
@@ -1367,7 +1383,7 @@ find $BUILD -name '*.packlist' -exec rm -f {} \;
 
 # create our directory structure
 # rsync is used to avoid copying non-binary modules or other extra stuff
-if [ "$PERL_512" -o "$PERL_514" -o "$PERL_516" -o "$PERL_518" -o "$PERL_520" ]; then
+if [ "$PERL_512" -o "$PERL_514" -o "$PERL_516" -o "$PERL_518" -o "$PERL_520" -o "$PERL_522" ]; then
     # Check for Perl using use64bitint and add -64int
     ARCH=`$PERL_BIN -MConfig -le 'print $Config{archname}' | sed 's/gnu-//' | sed 's/^i[3456]86-/i386-/' | sed 's/armv.*?-/arm-/' `
 fi


### PR DESCRIPTION
Small change to allow CPAN modules to be built on fedora 23. Tested on x86_64 platform.
