### PR TITLE
Remove strict gcc dependency from buildme.sh for FreeBSD 11.0 and up.

### DIFF
--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -132,7 +132,7 @@ echo "Looks like your compiler is $GCC"
 $GCC --version
 
 CC_TYPE=`$GCC --version`
-PERL_CC=`$ARCHPERL -V | grep cc=\' | sed "s#.*cc=\'##g" | sed "s#\',\ ccflags.*##g"`
+PERL_CC=`$ARCHPERL -V | grep cc=\' | sed "s#.*cc=\'##g" | sed "s#\',.*##g"`
 
 if [[ "$PERL_CC" != "$GCC" ]]; then
     echo "********************************************** WARNING *************************************"

--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -98,7 +98,7 @@ if [ "$OS" = "FreeBSD" ]; then
     BSD_MINOR_VER=`uname -r | sed 's/.*\.//g'`
     if [ $BSD_MAJOR_VER -ge 11 ]; then
         if [ -z ${CC} ] && [ -f "/etc/make.conf" ]; then
-            GCC=`grep CC /etc/make.conf | grep -v CCACHE | sed 's#CC=##g'`
+            GCC=`grep CC /etc/make.conf | grep -v CCACHE | grep -v # | sed 's#CC=##g'`
         elif [ -z $CC ]; then
             GCC=cc
         fi
@@ -582,8 +582,7 @@ function build {
                 elif [ "$OS" = 'FreeBSD' ]; then
                     ICUFLAGS="$FLAGS -DU_USING_ICU_NAMESPACE=0"
                     ICUOS="FreeBSD"
-                    ICUCOMPILER=`$GCC --version`
-                    if [[ $BSD_MAJOR_VER -ge 11 ]] && [[ $ICUCOMPILER == *clang* ]]; then
+                    if [[ $BSD_MAJOR_VER -ge 11 ]]; then
                         patch -p0 < ../../runConfigureICU.patch
                     fi
                 fi

--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -97,9 +97,12 @@ if [ "$OS" = "FreeBSD" ]; then
     BSD_MAJOR_VER=`uname -r | sed 's/\..*//g'`
     BSD_MINOR_VER=`uname -r | sed 's/.*\.//g'`
     if [ $BSD_MAJOR_VER -ge 11 ]; then
-        if [ -z ${CC} ] && [ -f "/etc/make.conf" ]; then
-            GCC=`grep CC /etc/make.conf | grep -v CCACHE | grep -v # | sed 's#CC=##g'`
-        elif [ -z $CC ]; then
+        if [ -f "/etc/make.conf" ]; then
+           MAKE_CC=`grep CC /etc/make.conf | grep -v CCACHE | grep -v \# | sed 's#CC=##g'`
+        fi
+        if [[ -z $MAKE_CC ]]; then
+            GCC=MAKE_CC
+        else
             GCC=cc
         fi
     fi
@@ -113,7 +116,7 @@ for i in $GCC cpp rsync make rsync ; do
     fi
 done
 
-echo "Looks like your compiler is $CC"
+echo "Looks like your compiler is $GCC"
 $GCC --version
 
 which yasm > /dev/null

--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -96,7 +96,6 @@ GCC=gcc
 if [ "$OS" = "FreeBSD" ]; then
     BSD_MAJOR_VER=`uname -r | sed 's/\..*//g'`
     BSD_MINOR_VER=`uname -r | sed 's/.*\.//g'`
-    if [ $BSD_MAJOR_VER -ge 11 ]; then
         if [ -f "/etc/make.conf" ]; then
            MAKE_CC=`grep CC /etc/make.conf | grep -v CCACHE | grep -v \# | sed 's#CC=##g'`
            MAKE_CXX=`grep CXX /etc/make.conf | grep -v CCACHE | grep -v \# | sed 's#CXX=##g'`
@@ -104,13 +103,17 @@ if [ "$OS" = "FreeBSD" ]; then
         fi
         if [[ ! -z "$MAKE_CC" ]]; then
             GCC="$MAKE_CC"
-        else
+        elif [ $BSD_MAJOR_VER -ge 10 ]; then
             GCC=cc
+        else
+            GCC=gcc
         fi
         if [[ ! -z "$MAKE_CXX" ]]; then
             GXX="$MAKE_CXX"
-        else
+        elif [ $BSD_MAJOR_VER -ge 10 ]; then
             GXX=c++
+        else
+            GCC=g++
         fi
         if [[ ! -z "$MAKE_CPP" ]]; then
             GPP="$MAKE_CPP"

--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -99,11 +99,23 @@ if [ "$OS" = "FreeBSD" ]; then
     if [ $BSD_MAJOR_VER -ge 11 ]; then
         if [ -f "/etc/make.conf" ]; then
            MAKE_CC=`grep CC /etc/make.conf | grep -v CCACHE | grep -v \# | sed 's#CC=##g'`
+           MAKE_CXX=`grep CXX /etc/make.conf | grep -v CCACHE | grep -v \# | sed 's#CXX=##g'`
+           MAKE_CPP=`grep CPP /etc/make.conf | grep -v CCACHE | grep -v \# | sed 's#CPP=##g'`
         fi
-        if [[ -z $MAKE_CC ]]; then
-            GCC=MAKE_CC
+        if [[ ! -z "$MAKE_CC" ]]; then
+            GCC="$MAKE_CC"
         else
             GCC=cc
+        fi
+        if [[ ! -z "$MAKE_CXX" ]]; then
+            GXX="$MAKE_CXX"
+        else
+            GXX=c++
+        fi
+        if [[ ! -z "$MAKE_CPP" ]]; then
+            GPP="$MAKE_CPP"
+        else
+            GPP=cpp
         fi
     fi
 fi
@@ -118,6 +130,19 @@ done
 
 echo "Looks like your compiler is $GCC"
 $GCC --version
+
+PERL_CC=`perl -V | grep cc=\' | sed "s#.*cc=\'##g" | sed "s#\',\ ccflags.*##g"`
+
+if [[ "$PERL_CC" != "$GCC" ]]; then
+    echo "********************************************** WARNING *************************************"
+    echo "*                                                                                          *"
+    echo "*    Perl was compiled with $PERL_CC, which is different than $GCC."
+    echo "*    This will likely cause significant problems.                                          *"
+    echo "*                                                                                          *"
+    echo "* Press CTRL^C to stop the build now...                                                                                         *"
+    echo "********************************************************************************************"
+    sleep 5
+fi
 
 which yasm > /dev/null
 if [ $? -ne 0 ] ; then

--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -132,7 +132,7 @@ echo "Looks like your compiler is $GCC"
 $GCC --version
 
 CC_TYPE=`$GCC --version`
-PERL_CC=`perl -V | grep cc=\' | sed "s#.*cc=\'##g" | sed "s#\',\ ccflags.*##g"`
+PERL_CC=`$ARCHPERL -V | grep cc=\' | sed "s#.*cc=\'##g" | sed "s#\',\ ccflags.*##g"`
 
 if [[ "$PERL_CC" != "$GCC" ]]; then
     echo "********************************************** WARNING *************************************"

--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -131,17 +131,19 @@ done
 echo "Looks like your compiler is $GCC"
 $GCC --version
 
+CC_TYPE=`$GCC --version`
 PERL_CC=`perl -V | grep cc=\' | sed "s#.*cc=\'##g" | sed "s#\',\ ccflags.*##g"`
 
 if [[ "$PERL_CC" != "$GCC" ]]; then
     echo "********************************************** WARNING *************************************"
     echo "*                                                                                          *"
-    echo "*    Perl was compiled with $PERL_CC, which is different than $GCC."
+    echo "*    Perl was compiled with $PERL_CC,"
+    echo "*    which is different than $GCC."
     echo "*    This will likely cause significant problems.                                          *"
     echo "*                                                                                          *"
-    echo "* Press CTRL^C to stop the build now...                                                                                         *"
+    echo "* Press CTRL^C to stop the build now...                                                    *"
     echo "********************************************************************************************"
-    sleep 5
+    sleep 3
 fi
 
 which yasm > /dev/null

--- a/CPAN/runConfigureICU.patch
+++ b/CPAN/runConfigureICU.patch
@@ -1,0 +1,27 @@
+--- runConfigureICU.orig	2010-08-30 12:24:42.000000000 -0700
++++ runConfigureICU	2017-07-23 20:39:59.019285000 -0700
+@@ -278,11 +278,21 @@
+         ;;
+     *BSD)
+         THE_OS="BSD"
+-        THE_COMP="the GNU C++"
+-        CC=gcc; export CC
+-        CXX=g++; export CXX
++        THE_COMP="the Clang++"
++        if [ -f /usr/local/libexec/ccache/cc ]; then
++            CC=/usr/local/libexec/ccache/cc; export CC
++        else
++            CC=cc; export CC
++        fi 
++        if [ -f /usr/local/libexec/ccache/cc ]; then
++            CXX=/usr/local/libexec/ccache/c++; export CXX
++        else
++            CXX=c++; export CXX
++        fi
+         DEBUG_CFLAGS='-g -O0'
+         DEBUG_CXFLAGS='-g -O0'
++        RELEASE_CFLAGS=-O3
++        RELEASE_CXXFLAGS=-O3
+         ;;
+     TRU64V5.1/CXX)
+         THE_OS="OSF1"

--- a/CPAN/runConfigureICU.patch
+++ b/CPAN/runConfigureICU.patch
@@ -1,6 +1,6 @@
---- runConfigureICU.orig	2010-08-30 12:24:42.000000000 -0700
-+++ runConfigureICU	2017-07-23 20:39:59.019285000 -0700
-@@ -278,11 +278,21 @@
+--- runConfigureICU.orig	2010-08-30 19:24:42.000000000 +0000
++++ runConfigureICU	2017-08-11 00:48:45.286653000 +0000
+@@ -278,11 +278,31 @@
          ;;
      *BSD)
          THE_OS="BSD"
@@ -8,15 +8,25 @@
 -        CC=gcc; export CC
 -        CXX=g++; export CXX
 +        THE_COMP="the Clang++"
-+        if [ -f /usr/local/libexec/ccache/cc ]; then
-+            CC=/usr/local/libexec/ccache/cc; export CC
++        if [ -f "/etc/make.conf" ]; then
++           MAKE_CC=`grep CC /etc/make.conf | grep -v CCACHE | grep -v \# | sed 's#CC=##g'`
++           MAKE_CXX=`grep CXX /etc/make.conf | grep -v CCACHE | grep -v \# | sed 's#CXX=##g'`
++           MAKE_CPP=`grep CPP /etc/make.conf | grep -v CCACHE | grep -v \# | sed 's#CPP=##g'`
++        fi
++        if [[ ! -z "$MAKE_CC" ]]; then
++            CC="$MAKE_CC"; export CC
 +        else
 +            CC=cc; export CC
-+        fi 
-+        if [ -f /usr/local/libexec/ccache/cc ]; then
-+            CXX=/usr/local/libexec/ccache/c++; export CXX
++        fi
++        if [[ ! -z "$MAKE_CXX" ]]; then
++            CXX="$MAKE_CXX"; export CXX
 +        else
 +            CXX=c++; export CXX
++        fi
++        if [[ ! -z "$MAKE_CPP" ]]; then
++            CPP="$MAKE_CPP"; export CPP
++        else
++            CPP=cpp; export CPP
 +        fi
          DEBUG_CFLAGS='-g -O0'
          DEBUG_CXFLAGS='-g -O0'


### PR DESCRIPTION
As mentioned elsewhere, GCC is no longer the default compiler for FreeBSD. This commit permits FreeBSD to build everything with clang (or whatever's specified in /etc/make.conf).