### PR TITLE
Add FreeBSD build tools for alac (not gcc dependent).

### DIFF
--- a/alac_decoder/Makefile.freebsd
+++ b/alac_decoder/Makefile.freebsd
@@ -1,0 +1,21 @@
+CC=cc
+RM=rm -f
+CFLAGS=-ggdb -O3 -W -Wall
+
+C_SOURCES=alac.c \
+          demux.c \
+          main.c \
+          stream.c \
+          wavwriter.c
+
+OBJECTS=$(C_SOURCES:.c=.o)
+
+alac: $(OBJECTS)
+	$(CC) -o alac $(OBJECTS)
+
+%.o: %.c
+	$(CC) -c $(CFLAGS) $< -o $@
+
+clean:
+	rm -f $(OBJECTS) *.*~ alac
+

--- a/alac_decoder/build-freebsd.sh
+++ b/alac_decoder/build-freebsd.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+MAKEFILE=$1
+DEST=$2
+
+gmake -f $MAKEFILE
+cp alac $DEST


### PR DESCRIPTION
Now we can build alac_decoder for FreeBSD. Doesn't require gcc.