### PR TITLE
Add flac build script & patch for FreeBSD (using clang).

### DIFF
--- a/flac/buildme-freebsd.sh
+++ b/flac/buildme-freebsd.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+OGG=1.1.3
+FLAC=1.2.1
+LOG=$PWD/config.log
+ARCH=`uname -m`
+CHANGENO=`git rev-parse --short HEAD`
+OUTPUT=$PWD/flac-build-$ARCH-$CHANGENO
+
+if [ -f "/etc/make.conf" ]; then
+    CC=`grep CC /etc/make.conf | grep -v CCACHE | sed 's#CC=##g'`
+    CXX=`grep CXX /etc/make.conf | grep -v CCACHE | sed 's#CXX=##g'`
+fi
+
+if [ -z $CC ]; then
+    CC=cc
+fi
+
+if [ -z $CXX ]; then
+    CXX=c++
+fi
+
+
+# Clean up
+rm -rf $OUTPUT
+rm -rf flac-$FLAC
+
+## Start
+echo "Most log mesages sent to $LOG... only 'errors' displayed here"
+date > $LOG
+
+## Build Ogg first
+echo "Untarring libogg-$OGG.tar.gz..."
+tar -zxf libogg-$OGG.tar.gz
+cd libogg-$OGG
+echo "Configuring..."
+CC=$CC CXX=$CXX ./configure --disable-shared >> $LOG
+echo "Running make..."
+gmake >> $LOG
+cd ..
+
+## Build
+echo "Untarring..."
+tar zxvf flac-$FLAC.tar.gz >> $LOG
+cd flac-$FLAC >> $LOG
+patch -p0 < ../sc.patch >> $LOG
+patch -p0 < ../triode-ignore-wav-length.patch >> $LOG
+patch -p0 < ../steven-allow-bad-ssnd-chunk-size.patch >> $LOG
+patch -p0 < ../flac_configure.in.patch >> $LOG
+mv configure.in configure.ac
+autoreconf -fi
+./autogen.sh
+CC=$CC CXX=$CXX \
+./configure --with-ogg-includes=$PWD/../libogg-$OGG/include --with-ogg-libraries=$PWD/../libogg-$OGG/src/.libs/ --disable-doxygen-docs --disable-oggtest --disable-shared --disable-xmms-plugin --disable-cpplibs --prefix $OUTPUT >> $LOG
+echo "Running make"
+gmake >> $LOG
+echo "Running make install"
+gmake install >> $LOG
+cd ..
+
+## Tar the whole package up
+tar -zcvf $OUTPUT.tgz $OUTPUT
+rm -rf $OUTPUT
+rm -rf flac-$FLAC
+rm -rf libogg-$OGG

--- a/flac/flac_configure.in.patch
+++ b/flac/flac_configure.in.patch
@@ -1,0 +1,13 @@
+--- configure.in.orig	2007-09-13 11:48:42.000000000 -0400
++++ configure.in	2017-07-29 16:39:26.368208000 -0400
+@@ -300,8 +302,8 @@
+ else
+ 	CPPFLAGS="-DNDEBUG $CPPFLAGS"
+ 	if test "x$GCC" = xyes; then
+-		CPPFLAGS="-DFLaC__INLINE=__inline__ $CPPFLAGS"
+-		CFLAGS="-O3 -funroll-loops -finline-functions -Wall -W -Winline $CFLAGS"
++		CPPFLAGS="-fPIC -DFLaC__INLINE=__inline__ $CPPFLAGS"
++		CFLAGS="-O3 -fPIC -funroll-loops -Wall -W -Winline $CFLAGS"
+ 	fi
+ fi
+ 


### PR DESCRIPTION
Now we can build flac on FreeBSD. The bundled 7.2 binaries can't be uses above FreeBSD 9.