### PR TITLE
Allow configure scripts to run on Linux aarch64 platforms, without breaking others 

### DIFF
--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -398,6 +398,15 @@ function tar_wrapper {
     echo "tar done"
 }
 
+function refresh_config {
+    if [ "`uname -m`" == "aarch64" -a "$OS" == "Linux"  ]; then
+        [ -f /tmp/config.guess.$$ ] || wget -O /tmp/config.guess.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'
+        [ -f /tmp/config.sub.$$ ] || wget -O /tmp/config.sub.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'
+        cp -vf /tmp/config.guess.$$ ./config.guess
+        cp -vf /tmp/config.sub.$$ ./config.sub
+    fi
+}
+
 # $1 = module to build
 # $2 = Makefile.PL arg(s)
 # $3 = run tests if 1 - default to $RUN_TESTS
@@ -557,6 +566,7 @@ function build {
             if [ ! -f build/lib/libicudata_s.a ]; then
                 tar_wrapper zxvf icu4c-4_6-src.tgz
                 cd icu/source
+                refresh_config
                 if [ "$OS" = 'Darwin' ]; then
                     ICUFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -DU_USING_ICU_NAMESPACE=0 -DU_CHARSET_IS_UTF8=1" # faster code for native UTF-8 systems
                     ICUOS="MacOSX"
@@ -780,6 +790,7 @@ function build {
             # Build libmysqlclient
             tar_wrapper jxvf mysql-5.1.37.tar.bz2
             cd mysql-5.1.37
+            refresh_config
             CC=gcc CXX=gcc \
             CFLAGS="-O3 -fno-omit-frame-pointer $FLAGS $OSX_ARCH $OSX_FLAGS" \
             CXXFLAGS="-O3 -fno-omit-frame-pointer -felide-constructors -fno-exceptions -fno-rtti $FLAGS $OSX_ARCH $OSX_FLAGS" \
@@ -811,7 +822,9 @@ function build {
         XML::Parser)
             # build expat
             tar_wrapper zxvf expat-2.0.1.tar.gz
-            cd expat-2.0.1
+            cd expat-2.0.1/conftools
+            refresh_config
+            cd ..
             CFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS" \
             LDFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS" \
                 ./configure --prefix=$BUILD \
@@ -847,6 +860,7 @@ function build {
             # build freetype
             tar_wrapper zxvf freetype-2.4.2.tar.gz
             cd freetype-2.4.2
+            refresh_config
             
             # Disable features we don't need for CODE2000
             cp -fv ../freetype-ftoption.h objs/ftoption.h
@@ -913,6 +927,7 @@ function build {
 			if [ "$OS" = "FreeBSD" ]; then
             	patch -p1 < ../libmediascan-freebsd.patch
             fi
+            refresh_config
 
             CFLAGS="-I$BUILD/include $FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
             LDFLAGS="-L$BUILD/lib $FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
@@ -972,6 +987,7 @@ function build_libexif {
     # build libexif
     tar_wrapper jxvf libexif-0.6.20.tar.bz2
     cd libexif-0.6.20
+    refresh_config
     
     CFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
     LDFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
@@ -1113,7 +1129,7 @@ function build_libjpeg {
     else
         tar_wrapper zxvf jpegsrc.v8b.tar.gz
         cd jpeg-8b
-        
+        refresh_config
         # Disable features we don't need
         cp -fv ../libjpeg-jmorecfg.h jmorecfg.h
         
@@ -1146,6 +1162,7 @@ function build_libpng {
     
     # Disable features we don't need
     cp -fv ../libpng-pngconf.h pngconf.h
+    refresh_config
     
     CFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
     LDFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
@@ -1170,6 +1187,7 @@ function build_giflib {
     # build giflib
     tar_wrapper zxvf giflib-4.1.6.tar.gz
     cd giflib-4.1.6
+    refresh_config
     CFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
     LDFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
         ./configure --prefix=$BUILD \
@@ -1195,6 +1213,7 @@ function build_ffmpeg {
     # build ffmpeg, enabling only the things libmediascan uses
     tar_wrapper jxvf ffmpeg-0.8.4.tar.bz2
     cd ffmpeg-0.8.4
+    refresh_config
     
     if [ "$MACHINE" = "padre" ]; then
         patch -p0 < ../ffmpeg-padre-configure.patch
@@ -1352,7 +1371,9 @@ function build_bdb {
     
     # build bdb
     tar_wrapper zxvf db-5.1.25.tar.gz
-    cd db-5.1.25/build_unix
+    cd db-5.1.25/dist
+    refresh_config
+    cd ../build_unix
     
     if [ "$OS" = "Darwin" -o "$OS" = "FreeBSD" ]; then
        pushd ..

--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -354,14 +354,6 @@ function tar_wrapper {
     echo "tar done"
 }
 
-function refresh_config {
-    if [ "`uname -m`" == "aarch64" -a "$OS" == "Linux"  ]; then
-        [ -f /tmp/config.guess.$$ ] || wget -O /tmp/config.guess.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'
-        [ -f /tmp/config.sub.$$ ] || wget -O /tmp/config.sub.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'
-        cp -vf /tmp/config.guess.$$ ./config.guess
-        cp -vf /tmp/config.sub.$$ ./config.sub
-    fi
-}
 
 # $1 = module to build
 # $2 = Makefile.PL arg(s)
@@ -522,7 +514,7 @@ function build {
             if [ ! -f build/lib/libicudata_s.a ]; then
                 tar_wrapper zxvf icu4c-4_6-src.tgz
                 cd icu/source
-                refresh_config
+                . ../../update-config.sh
                 if [ "$OS" = 'Darwin' ]; then
                     ICUFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -DU_USING_ICU_NAMESPACE=0 -DU_CHARSET_IS_UTF8=1" # faster code for native UTF-8 systems
                     ICUOS="MacOSX"
@@ -757,7 +749,7 @@ function build {
             # Build libmysqlclient
             tar_wrapper jxvf mysql-5.1.37.tar.bz2
             cd mysql-5.1.37
-            refresh_config
+            . ../update-config.sh
             CC=gcc CXX=gcc \
             CFLAGS="-O3 -fno-omit-frame-pointer $FLAGS $OSX_ARCH $OSX_FLAGS" \
             CXXFLAGS="-O3 -fno-omit-frame-pointer -felide-constructors -fno-exceptions -fno-rtti $FLAGS $OSX_ARCH $OSX_FLAGS" \
@@ -790,7 +782,7 @@ function build {
             # build expat
             tar_wrapper zxvf expat-2.0.1.tar.gz
             cd expat-2.0.1/conftools
-            refresh_config
+            . ../../update-config.sh
             cd ..
             CFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS" \
             LDFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS" \
@@ -827,7 +819,7 @@ function build {
             # build freetype
             tar_wrapper zxvf freetype-2.4.2.tar.gz
             cd freetype-2.4.2
-            refresh_config
+            . ../update-config.sh
             
             # Disable features we don't need for CODE2000
             cp -fv ../freetype-ftoption.h objs/ftoption.h
@@ -894,7 +886,7 @@ function build {
 			if [ "$OS" = "FreeBSD" ]; then
             	patch -p1 < ../libmediascan-freebsd.patch
             fi
-            refresh_config
+            . ../update-config.sh
 
             CFLAGS="-I$BUILD/include $FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
             LDFLAGS="-L$BUILD/lib $FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
@@ -954,7 +946,7 @@ function build_libexif {
     # build libexif
     tar_wrapper jxvf libexif-0.6.20.tar.bz2
     cd libexif-0.6.20
-    refresh_config
+    . ../update-config.sh
     
     CFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
     LDFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
@@ -1096,7 +1088,7 @@ function build_libjpeg {
     else
         tar_wrapper zxvf jpegsrc.v8b.tar.gz
         cd jpeg-8b
-        refresh_config
+        . ../update-config.sh
         # Disable features we don't need
         cp -fv ../libjpeg-jmorecfg.h jmorecfg.h
         
@@ -1129,7 +1121,7 @@ function build_libpng {
     
     # Disable features we don't need
     cp -fv ../libpng-pngconf.h pngconf.h
-    refresh_config
+    . ../update-config.sh
     
     CFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
     LDFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
@@ -1154,7 +1146,7 @@ function build_giflib {
     # build giflib
     tar_wrapper zxvf giflib-4.1.6.tar.gz
     cd giflib-4.1.6
-    refresh_config
+    . ../update-config.sh
     CFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
     LDFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
         ./configure --prefix=$BUILD \
@@ -1180,7 +1172,7 @@ function build_ffmpeg {
     # build ffmpeg, enabling only the things libmediascan uses
     tar_wrapper jxvf ffmpeg-0.8.4.tar.bz2
     cd ffmpeg-0.8.4
-    refresh_config
+    . ../update-config.sh
     
     if [ "$MACHINE" = "padre" ]; then
         patch -p0 < ../ffmpeg-padre-configure.patch
@@ -1339,7 +1331,7 @@ function build_bdb {
     # build bdb
     tar_wrapper zxvf db-5.1.25.tar.gz
     cd db-5.1.25/dist
-    refresh_config
+    . ../../update-config.sh
     cd ../build_unix
     
     if [ "$OS" = "Darwin" -o "$OS" = "FreeBSD" ]; then

--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -354,6 +354,15 @@ function tar_wrapper {
     echo "tar done"
 }
 
+function refresh_config {
+    if [ "`uname -m`" == "aarch64" -a "$OS" == "Linux"  ]; then
+        [ -f /tmp/config.guess.$$ ] || wget -O /tmp/config.guess.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'
+        [ -f /tmp/config.sub.$$ ] || wget -O /tmp/config.sub.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'
+        cp -vf /tmp/config.guess.$$ ./config.guess
+        cp -vf /tmp/config.sub.$$ ./config.sub
+    fi
+}
+
 # $1 = module to build
 # $2 = Makefile.PL arg(s)
 # $3 = run tests if 1 - default to $RUN_TESTS
@@ -513,6 +522,7 @@ function build {
             if [ ! -f build/lib/libicudata_s.a ]; then
                 tar_wrapper zxvf icu4c-4_6-src.tgz
                 cd icu/source
+                refresh_config
                 if [ "$OS" = 'Darwin' ]; then
                     ICUFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -DU_USING_ICU_NAMESPACE=0 -DU_CHARSET_IS_UTF8=1" # faster code for native UTF-8 systems
                     ICUOS="MacOSX"
@@ -747,6 +757,7 @@ function build {
             # Build libmysqlclient
             tar_wrapper jxvf mysql-5.1.37.tar.bz2
             cd mysql-5.1.37
+            refresh_config
             CC=gcc CXX=gcc \
             CFLAGS="-O3 -fno-omit-frame-pointer $FLAGS $OSX_ARCH $OSX_FLAGS" \
             CXXFLAGS="-O3 -fno-omit-frame-pointer -felide-constructors -fno-exceptions -fno-rtti $FLAGS $OSX_ARCH $OSX_FLAGS" \
@@ -778,7 +789,9 @@ function build {
         XML::Parser)
             # build expat
             tar_wrapper zxvf expat-2.0.1.tar.gz
-            cd expat-2.0.1
+            cd expat-2.0.1/conftools
+            refresh_config
+            cd ..
             CFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS" \
             LDFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS" \
                 ./configure --prefix=$BUILD \
@@ -814,6 +827,7 @@ function build {
             # build freetype
             tar_wrapper zxvf freetype-2.4.2.tar.gz
             cd freetype-2.4.2
+            refresh_config
             
             # Disable features we don't need for CODE2000
             cp -fv ../freetype-ftoption.h objs/ftoption.h
@@ -880,6 +894,7 @@ function build {
 			if [ "$OS" = "FreeBSD" ]; then
             	patch -p1 < ../libmediascan-freebsd.patch
             fi
+            refresh_config
 
             CFLAGS="-I$BUILD/include $FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
             LDFLAGS="-L$BUILD/lib $FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
@@ -939,6 +954,7 @@ function build_libexif {
     # build libexif
     tar_wrapper jxvf libexif-0.6.20.tar.bz2
     cd libexif-0.6.20
+    refresh_config
     
     CFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
     LDFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
@@ -1080,7 +1096,7 @@ function build_libjpeg {
     else
         tar_wrapper zxvf jpegsrc.v8b.tar.gz
         cd jpeg-8b
-        
+        refresh_config
         # Disable features we don't need
         cp -fv ../libjpeg-jmorecfg.h jmorecfg.h
         
@@ -1113,6 +1129,7 @@ function build_libpng {
     
     # Disable features we don't need
     cp -fv ../libpng-pngconf.h pngconf.h
+    refresh_config
     
     CFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
     LDFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
@@ -1137,6 +1154,7 @@ function build_giflib {
     # build giflib
     tar_wrapper zxvf giflib-4.1.6.tar.gz
     cd giflib-4.1.6
+    refresh_config
     CFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
     LDFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
         ./configure --prefix=$BUILD \
@@ -1162,6 +1180,7 @@ function build_ffmpeg {
     # build ffmpeg, enabling only the things libmediascan uses
     tar_wrapper jxvf ffmpeg-0.8.4.tar.bz2
     cd ffmpeg-0.8.4
+    refresh_config
     
     if [ "$MACHINE" = "padre" ]; then
         patch -p0 < ../ffmpeg-padre-configure.patch
@@ -1319,7 +1338,9 @@ function build_bdb {
     
     # build bdb
     tar_wrapper zxvf db-5.1.25.tar.gz
-    cd db-5.1.25/build_unix
+    cd db-5.1.25/dist
+    refresh_config
+    cd ../build_unix
     
     if [ "$OS" = "Darwin" -o "$OS" = "FreeBSD" ]; then
        pushd ..

--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -398,14 +398,6 @@ function tar_wrapper {
     echo "tar done"
 }
 
-function refresh_config {
-    if [ "`uname -m`" == "aarch64" -a "$OS" == "Linux"  ]; then
-        [ -f /tmp/config.guess.$$ ] || wget -O /tmp/config.guess.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'
-        [ -f /tmp/config.sub.$$ ] || wget -O /tmp/config.sub.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'
-        cp -vf /tmp/config.guess.$$ ./config.guess
-        cp -vf /tmp/config.sub.$$ ./config.sub
-    fi
-}
 
 # $1 = module to build
 # $2 = Makefile.PL arg(s)
@@ -566,7 +558,7 @@ function build {
             if [ ! -f build/lib/libicudata_s.a ]; then
                 tar_wrapper zxvf icu4c-4_6-src.tgz
                 cd icu/source
-                refresh_config
+                . ../../update-config.sh
                 if [ "$OS" = 'Darwin' ]; then
                     ICUFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -DU_USING_ICU_NAMESPACE=0 -DU_CHARSET_IS_UTF8=1" # faster code for native UTF-8 systems
                     ICUOS="MacOSX"
@@ -790,7 +782,7 @@ function build {
             # Build libmysqlclient
             tar_wrapper jxvf mysql-5.1.37.tar.bz2
             cd mysql-5.1.37
-            refresh_config
+            . ../update-config.sh
             CC=gcc CXX=gcc \
             CFLAGS="-O3 -fno-omit-frame-pointer $FLAGS $OSX_ARCH $OSX_FLAGS" \
             CXXFLAGS="-O3 -fno-omit-frame-pointer -felide-constructors -fno-exceptions -fno-rtti $FLAGS $OSX_ARCH $OSX_FLAGS" \
@@ -823,7 +815,7 @@ function build {
             # build expat
             tar_wrapper zxvf expat-2.0.1.tar.gz
             cd expat-2.0.1/conftools
-            refresh_config
+            . ../../update-config.sh
             cd ..
             CFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS" \
             LDFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS" \
@@ -860,7 +852,7 @@ function build {
             # build freetype
             tar_wrapper zxvf freetype-2.4.2.tar.gz
             cd freetype-2.4.2
-            refresh_config
+            . ../update-config.sh
             
             # Disable features we don't need for CODE2000
             cp -fv ../freetype-ftoption.h objs/ftoption.h
@@ -927,7 +919,7 @@ function build {
 			if [ "$OS" = "FreeBSD" ]; then
             	patch -p1 < ../libmediascan-freebsd.patch
             fi
-            refresh_config
+            . ../update-config.sh
 
             CFLAGS="-I$BUILD/include $FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
             LDFLAGS="-L$BUILD/lib $FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
@@ -987,7 +979,7 @@ function build_libexif {
     # build libexif
     tar_wrapper jxvf libexif-0.6.20.tar.bz2
     cd libexif-0.6.20
-    refresh_config
+    . ../update-config.sh
     
     CFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
     LDFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
@@ -1129,7 +1121,7 @@ function build_libjpeg {
     else
         tar_wrapper zxvf jpegsrc.v8b.tar.gz
         cd jpeg-8b
-        refresh_config
+        . ../update-config.sh
         # Disable features we don't need
         cp -fv ../libjpeg-jmorecfg.h jmorecfg.h
         
@@ -1162,7 +1154,7 @@ function build_libpng {
     
     # Disable features we don't need
     cp -fv ../libpng-pngconf.h pngconf.h
-    refresh_config
+    . ../update-config.sh
     
     CFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
     LDFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
@@ -1187,7 +1179,7 @@ function build_giflib {
     # build giflib
     tar_wrapper zxvf giflib-4.1.6.tar.gz
     cd giflib-4.1.6
-    refresh_config
+    . ../update-config.sh
     CFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
     LDFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
         ./configure --prefix=$BUILD \
@@ -1213,7 +1205,7 @@ function build_ffmpeg {
     # build ffmpeg, enabling only the things libmediascan uses
     tar_wrapper jxvf ffmpeg-0.8.4.tar.bz2
     cd ffmpeg-0.8.4
-    refresh_config
+    . ../update-config.sh
     
     if [ "$MACHINE" = "padre" ]; then
         patch -p0 < ../ffmpeg-padre-configure.patch
@@ -1372,7 +1364,7 @@ function build_bdb {
     # build bdb
     tar_wrapper zxvf db-5.1.25.tar.gz
     cd db-5.1.25/dist
-    refresh_config
+    . ../../update-config.sh
     cd ../build_unix
     
     if [ "$OS" = "Darwin" -o "$OS" = "FreeBSD" ]; then

--- a/CPAN/update-config.sh
+++ b/CPAN/update-config.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-if [ "`uname -m`"=="aarch64" -a "`uname`"=="Linux"  ]; then
+if [ "`uname -m`" = "aarch64" -a "`uname`" = "Linux"  ]; then
     [ -f /tmp/config.guess.$$ ] || wget -O /tmp/config.guess.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'
     [ -f /tmp/config.sub.$$ ] || wget -O /tmp/config.sub.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'
     cp -vf /tmp/config.guess.$$ ./config.guess

--- a/CPAN/update-config.sh
+++ b/CPAN/update-config.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+if [ "`uname -m`"=="aarch64" -a "`uname`"=="Linux"  ]; then
+    [ -f /tmp/config.guess.$$ ] || wget -O /tmp/config.guess.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'
+    [ -f /tmp/config.sub.$$ ] || wget -O /tmp/config.sub.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'
+    cp -vf /tmp/config.guess.$$ ./config.guess
+    cp -vf /tmp/config.sub.$$ ./config.sub
+fi

--- a/flac/buildme-linux.sh
+++ b/flac/buildme-linux.sh
@@ -19,13 +19,7 @@ date > $LOG
 echo "Untarring libogg-$OGG.tar.gz..."
 tar -zxf libogg-$OGG.tar.gz
 cd libogg-$OGG
-if [ "$ARCH"=="aarch64" ]
-then
-    [ -f /tmp/config.guess.$$ ] || wget -q -O /tmp/config.guess.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' 
-    [ -f /tmp/config.sub.$$ ] || wget -q -O /tmp/config.sub.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' 
-    cp -vf /tmp/config.guess.$$ ./config.guess
-    cp -vf /tmp/config.sub.$$ ./config.sub
-fi
+. ../../CPAN/update-config.sh
 echo "Configuring..."
 ./configure --disable-shared >> $LOG
 echo "Running make..."
@@ -36,12 +30,7 @@ cd ..
 echo "Untarring..."
 tar zxvf flac-$FLAC.tar.gz >> $LOG
 cd flac-$FLAC >> $LOG
-if [ "$ARCH"=="aarch64" ]; then
-    [ -f /tmp/config.guess.$$ ] || wget -q -O /tmp/config.guess.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'
-    [ -f /tmp/config.sub.$$ ] || wget -q -O /tmp/config.sub.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'
-    cp -vf /tmp/config.guess.$$ ./config.guess
-    cp -vf /tmp/config.sub.$$ ./config.sub
-fi
+. ../../CPAN/update-config.sh
 patch -p0 < ../sc.patch >> $LOG
 patch -p0 < ../triode-ignore-wav-length.patch >> $LOG
 patch -p0 < ../steven-allow-bad-ssnd-chunk-size.patch >> $LOG

--- a/flac/buildme-linux.sh
+++ b/flac/buildme-linux.sh
@@ -19,6 +19,13 @@ date > $LOG
 echo "Untarring libogg-$OGG.tar.gz..."
 tar -zxf libogg-$OGG.tar.gz
 cd libogg-$OGG
+if [ "$ARCH"=="aarch64" ]
+then
+    [ -f /tmp/config.guess.$$ ] || wget -q -O /tmp/config.guess.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' 
+    [ -f /tmp/config.sub.$$ ] || wget -q -O /tmp/config.sub.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' 
+    cp -vf /tmp/config.guess.$$ ./config.guess
+    cp -vf /tmp/config.sub.$$ ./config.sub
+fi
 echo "Configuring..."
 ./configure --disable-shared >> $LOG
 echo "Running make..."
@@ -29,6 +36,12 @@ cd ..
 echo "Untarring..."
 tar zxvf flac-$FLAC.tar.gz >> $LOG
 cd flac-$FLAC >> $LOG
+if [ "$ARCH"=="aarch64" ]; then
+    [ -f /tmp/config.guess.$$ ] || wget -q -O /tmp/config.guess.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'
+    [ -f /tmp/config.sub.$$ ] || wget -q -O /tmp/config.sub.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'
+    cp -vf /tmp/config.guess.$$ ./config.guess
+    cp -vf /tmp/config.sub.$$ ./config.sub
+fi
 patch -p0 < ../sc.patch >> $LOG
 patch -p0 < ../triode-ignore-wav-length.patch >> $LOG
 patch -p0 < ../steven-allow-bad-ssnd-chunk-size.patch >> $LOG

--- a/sox/buildme-linux.sh
+++ b/sox/buildme-linux.sh
@@ -28,6 +28,13 @@ date > $LOG
 echo "Untarring libogg-$OGG.tar.gz..."
 tar -zxf libogg-$OGG.tar.gz 
 cd libogg-$OGG
+if [ "$ARCH"=="aarch64" ]
+then
+    [ -f /tmp/config.guess.$$ ] || wget -q -O /tmp/config.guess.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' 
+    [ -f /tmp/config.sub.$$ ] || wget -q -O /tmp/config.sub.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' 
+    cp -vf /tmp/config.guess.$$ ./config.guess
+    cp -vf /tmp/config.sub.$$ ./config.sub
+fi
 echo "Configuring..."
 ./configure --disable-shared >> $LOG
 echo "Running make..."
@@ -38,6 +45,13 @@ cd ..
 echo "Untarring libvorbis-$VORBIS.tar.gz..."
 tar -zxf libvorbis-$VORBIS.tar.gz
 cd libvorbis-$VORBIS
+if [ "$ARCH"=="aarch64" ]
+then
+    [ -f /tmp/config.guess.$$ ] || wget -q -O /tmp/config.guess.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' 
+    [ -f /tmp/config.sub.$$ ] || wget -q -O /tmp/config.sub.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' 
+    cp -vf /tmp/config.guess.$$ ./config.guess
+    cp -vf /tmp/config.sub.$$ ./config.sub
+fi
 echo "Configuring..."
 ./configure --with-ogg-includes=$PWD/../libogg-$OGG/include --with-ogg-libraries=$PWD/../libogg-$OGG/src/.libs --disable-shared >> $LOG
 echo "Running make"
@@ -48,6 +62,13 @@ cd ..
 echo "Untarring flac-$FLAC.tar.gz..."
 tar -zxf flac-$FLAC.tar.gz 
 cd flac-$FLAC
+if [ "$ARCH"=="aarch64" ]
+then
+    [ -f /tmp/config.guess.$$ ] || wget -q -O /tmp/config.guess.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' 
+    [ -f /tmp/config.sub.$$ ] || wget -q -O /tmp/config.sub.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' 
+    cp -vf /tmp/config.guess.$$ ./config.guess
+    cp -vf /tmp/config.sub.$$ ./config.sub
+fi
 echo "Configuring..."
 ./configure --with-ogg-includes=$PWD/../libogg-$OGG/include --with-ogg-libraries=$PWD/../libogg-$OGG/src/.libs/ --disable-shared --disable-xmms-plugin --disable-cpplibs >> $LOG
 echo "Running make"
@@ -58,6 +79,14 @@ cd ..
 echo "Untarring libmad-$MAD.tar.gz..."
 tar -zxf libmad-$MAD.tar.gz
 cd libmad-$MAD
+if [ "$ARCH"=="aarch64" ]
+then
+    [ -f /tmp/config.guess.$$ ] || wget -q -O /tmp/config.guess.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' 
+    [ -f /tmp/config.sub.$$ ] || wget -q -O /tmp/config.sub.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' 
+    cp -vf /tmp/config.guess.$$ ./config.guess
+    cp -vf /tmp/config.sub.$$ ./config.sub
+fi
+cp /usr/share/automake-1.15/config.guess .
 # Remove -fforce-mem line as it doesn't work with newer gcc
 sed -i 's/-fforce-mem//' configure
 echo "configuring..."
@@ -70,6 +99,13 @@ cd ..
 echo "Untarring wavpack-$WAVPACK.tar.bz2..."
 tar -jxf wavpack-$WAVPACK.tar.bz2
 cd wavpack-$WAVPACK
+if [ "$ARCH"=="aarch64" ]
+then
+    [ -f /tmp/config.guess.$$ ] || wget -q -O /tmp/config.guess.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' 
+    [ -f /tmp/config.sub.$$ ] || wget -q -O /tmp/config.sub.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' 
+    cp -vf /tmp/config.guess.$$ ./config.guess
+    cp -vf /tmp/config.sub.$$ ./config.sub
+fi
 echo "Configuring..."
 ./configure --disable-shared >> $LOG
 echo "Running make"
@@ -83,6 +119,13 @@ cd ../..
 echo "Untarring sox-$SOX.tar.gz..."
 tar -zxf sox-$SOX.tar.gz >> $LOG
 cd sox-$SOX >> $LOG
+if [ "$ARCH"=="aarch64" ]
+then
+    [ -f /tmp/config.guess.$$ ] || wget -q -O /tmp/config.guess.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' 
+    [ -f /tmp/config.sub.$$ ] || wget -q -O /tmp/config.sub.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' 
+    cp -vf /tmp/config.guess.$$ ./config.guess
+    cp -vf /tmp/config.sub.$$ ./config.sub
+fi
 echo "Configuring..."
 CPF="-I$PWD/../libogg-$OGG/include -I$PWD/../libvorbis-$VORBIS/include -I$PWD/../wavpack-$WAVPACK/include -I$PWD/../flac-$FLAC/include -I$PWD/../libmad-$MAD" 
 LDF="-L$PWD/../libogg-$OGG/src/.libs -L$PWD/../libvorbis-$VORBIS/lib/.libs -L$PWD/../wavpack-$WAVPACK/src/.libs -L$PWD/../libmad-$MAD/.libs -L$PWD/../flac-$FLAC/src/libFLAC/.libs"

--- a/sox/buildme-linux.sh
+++ b/sox/buildme-linux.sh
@@ -28,13 +28,7 @@ date > $LOG
 echo "Untarring libogg-$OGG.tar.gz..."
 tar -zxf libogg-$OGG.tar.gz 
 cd libogg-$OGG
-if [ "$ARCH"=="aarch64" ]
-then
-    [ -f /tmp/config.guess.$$ ] || wget -q -O /tmp/config.guess.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' 
-    [ -f /tmp/config.sub.$$ ] || wget -q -O /tmp/config.sub.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' 
-    cp -vf /tmp/config.guess.$$ ./config.guess
-    cp -vf /tmp/config.sub.$$ ./config.sub
-fi
+. ../../CPAN/update-config.sh
 echo "Configuring..."
 ./configure --disable-shared >> $LOG
 echo "Running make..."

--- a/sox/buildme-linux.sh
+++ b/sox/buildme-linux.sh
@@ -45,13 +45,7 @@ cd ..
 echo "Untarring libvorbis-$VORBIS.tar.gz..."
 tar -zxf libvorbis-$VORBIS.tar.gz
 cd libvorbis-$VORBIS
-if [ "$ARCH"=="aarch64" ]
-then
-    [ -f /tmp/config.guess.$$ ] || wget -q -O /tmp/config.guess.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' 
-    [ -f /tmp/config.sub.$$ ] || wget -q -O /tmp/config.sub.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' 
-    cp -vf /tmp/config.guess.$$ ./config.guess
-    cp -vf /tmp/config.sub.$$ ./config.sub
-fi
+. ../../CPAN/update-config.sh
 echo "Configuring..."
 ./configure --with-ogg-includes=$PWD/../libogg-$OGG/include --with-ogg-libraries=$PWD/../libogg-$OGG/src/.libs --disable-shared >> $LOG
 echo "Running make"
@@ -62,13 +56,7 @@ cd ..
 echo "Untarring flac-$FLAC.tar.gz..."
 tar -zxf flac-$FLAC.tar.gz 
 cd flac-$FLAC
-if [ "$ARCH"=="aarch64" ]
-then
-    [ -f /tmp/config.guess.$$ ] || wget -q -O /tmp/config.guess.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' 
-    [ -f /tmp/config.sub.$$ ] || wget -q -O /tmp/config.sub.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' 
-    cp -vf /tmp/config.guess.$$ ./config.guess
-    cp -vf /tmp/config.sub.$$ ./config.sub
-fi
+. ../../CPAN/update-config.sh
 echo "Configuring..."
 ./configure --with-ogg-includes=$PWD/../libogg-$OGG/include --with-ogg-libraries=$PWD/../libogg-$OGG/src/.libs/ --disable-shared --disable-xmms-plugin --disable-cpplibs >> $LOG
 echo "Running make"
@@ -79,13 +67,7 @@ cd ..
 echo "Untarring libmad-$MAD.tar.gz..."
 tar -zxf libmad-$MAD.tar.gz
 cd libmad-$MAD
-if [ "$ARCH"=="aarch64" ]
-then
-    [ -f /tmp/config.guess.$$ ] || wget -q -O /tmp/config.guess.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' 
-    [ -f /tmp/config.sub.$$ ] || wget -q -O /tmp/config.sub.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' 
-    cp -vf /tmp/config.guess.$$ ./config.guess
-    cp -vf /tmp/config.sub.$$ ./config.sub
-fi
+. ../../CPAN/update-config.sh
 cp /usr/share/automake-1.15/config.guess .
 # Remove -fforce-mem line as it doesn't work with newer gcc
 sed -i 's/-fforce-mem//' configure
@@ -99,13 +81,7 @@ cd ..
 echo "Untarring wavpack-$WAVPACK.tar.bz2..."
 tar -jxf wavpack-$WAVPACK.tar.bz2
 cd wavpack-$WAVPACK
-if [ "$ARCH"=="aarch64" ]
-then
-    [ -f /tmp/config.guess.$$ ] || wget -q -O /tmp/config.guess.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' 
-    [ -f /tmp/config.sub.$$ ] || wget -q -O /tmp/config.sub.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' 
-    cp -vf /tmp/config.guess.$$ ./config.guess
-    cp -vf /tmp/config.sub.$$ ./config.sub
-fi
+. ../../CPAN/update-config.sh
 echo "Configuring..."
 ./configure --disable-shared >> $LOG
 echo "Running make"
@@ -119,13 +95,7 @@ cd ../..
 echo "Untarring sox-$SOX.tar.gz..."
 tar -zxf sox-$SOX.tar.gz >> $LOG
 cd sox-$SOX >> $LOG
-if [ "$ARCH"=="aarch64" ]
-then
-    [ -f /tmp/config.guess.$$ ] || wget -q -O /tmp/config.guess.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' 
-    [ -f /tmp/config.sub.$$ ] || wget -q -O /tmp/config.sub.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' 
-    cp -vf /tmp/config.guess.$$ ./config.guess
-    cp -vf /tmp/config.sub.$$ ./config.sub
-fi
+. ../../CPAN/update-config.sh
 echo "Configuring..."
 CPF="-I$PWD/../libogg-$OGG/include -I$PWD/../libvorbis-$VORBIS/include -I$PWD/../wavpack-$WAVPACK/include -I$PWD/../flac-$FLAC/include -I$PWD/../libmad-$MAD" 
 LDF="-L$PWD/../libogg-$OGG/src/.libs -L$PWD/../libvorbis-$VORBIS/lib/.libs -L$PWD/../wavpack-$WAVPACK/src/.libs -L$PWD/../libmad-$MAD/.libs -L$PWD/../flac-$FLAC/src/libFLAC/.libs"

--- a/wavpack/build.sh
+++ b/wavpack/build.sh
@@ -38,6 +38,13 @@ mkdir $BUILD
 # Build wavpack
 tar jxvf wavpack-4.50.1.tar.bz2
 cd wavpack-4.50.1
+if [ "$ARCH"=="aarch64" ]
+then
+    [ -f /tmp/config.guess.$$ ] || wget -q -O /tmp/config.guess.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' 
+    [ -f /tmp/config.sub.$$ ] || wget -q -O /tmp/config.sub.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' 
+    cp -vf /tmp/config.guess.$$ ./config.guess
+    cp -vf /tmp/config.sub.$$ ./config.sub
+fi
 CFLAGS="$FLAGS" \
 LDFLAGS="$FLAGS" \
     ./configure --prefix=$BUILD \

--- a/wavpack/build.sh
+++ b/wavpack/build.sh
@@ -38,13 +38,7 @@ mkdir $BUILD
 # Build wavpack
 tar jxvf wavpack-4.50.1.tar.bz2
 cd wavpack-4.50.1
-if [ "$ARCH"=="aarch64" ]
-then
-    [ -f /tmp/config.guess.$$ ] || wget -q -O /tmp/config.guess.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' 
-    [ -f /tmp/config.sub.$$ ] || wget -q -O /tmp/config.sub.$$ 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' 
-    cp -vf /tmp/config.guess.$$ ./config.guess
-    cp -vf /tmp/config.sub.$$ ./config.sub
-fi
+. ../../CPAN/update-config.sh
 CFLAGS="$FLAGS" \
 LDFLAGS="$FLAGS" \
     ./configure --prefix=$BUILD \


### PR DESCRIPTION
I've tried to make these changes a minimal and low-impact as possible.  

The idea is to simply copy in from the latest config.guess and config.sub files from their source repos on the web at http://git.savannah.gnu.org/, but to do so only on platforms that wouldn't otherwise compile. There should therefore be no unwanted side effects on other platforms.

I created a bash function inside CPAN/buildme.sh named refresh_config(), that does the conditional copying of the files using wget.

Other possibilities were considered such as actually running automake to regenerate the configure scripts, which in some sense is the more "proper" approach, but this assumes a working automake, and would be more likely to fail IMO. 

Similar fixes were applied in the buildme-linux.sh for flac, sox and wavpack, but I did not use function calls in those cases, as I would need to change the script interpreter from Bourne shell to Bash, which may or may not be a good idea. 