### PR TITLE
remove unwanted cp command from previous method of refreshing config.guess

### DIFF
--- a/sox/buildme-linux.sh
+++ b/sox/buildme-linux.sh
@@ -62,7 +62,6 @@ echo "Untarring libmad-$MAD.tar.gz..."
 tar -zxf libmad-$MAD.tar.gz
 cd libmad-$MAD
 . ../../CPAN/update-config.sh
-cp /usr/share/automake-1.15/config.guess .
 # Remove -fforce-mem line as it doesn't work with newer gcc
 sed -i 's/-fforce-mem//' configure
 echo "configuring..."


### PR DESCRIPTION
Sorry, Michael, this cp command got left behind from my previous approach and should be removed.