### PR TITLE
Feature/x86 rename knob

### DIFF
--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -93,16 +93,7 @@ echo "RUN_TESTS:$RUN_TESTS CLEAN:$CLEAN USE_HINTS:$USE_HINTS target ${1-all}"
 OS=`uname`
 MACHINE=`uname -m`
 
-# get system arch, stripping out extra -gnu on Linux
-ARCHPERL=/usr/bin/perl
-if [ "$OS" = "FreeBSD" ]; then
-    ARCHPERL=/usr/local/bin/perl
-fi
-ARCH=`$ARCHPERL -MConfig -le 'print $Config{archname}' | sed 's/gnu-//' | sed 's/^i[3456]86-/i386-/' | sed 's/armv.*?-/arm-/' `
-
-if [ "$OS" = "Linux" -o "$OS" = "Darwin" -o "$OS" = "FreeBSD" -o "$OS" = "SunOS" ]; then
-    echo "Building for $OS / $ARCH"
-else
+if [ "$OS" != "Linux" -a "$OS" != "Darwin" -a "$OS" != "FreeBSD" -a "$OS" != "SunOS" ]; then
     echo "Unsupported platform: $OS, please submit a patch or provide us with access to a development system."
     exit
 fi
@@ -214,20 +205,6 @@ else
     echo "*"
     echo "********************************************************************************************"
     GCC_LIBCPP=false
-fi
-
-PERL_CC=`$ARCHPERL -V | grep cc=\' | sed "s#.*cc=\'##g" | sed "s#\'.*##g"`
-
-if [[ "$PERL_CC" != "$GCC" ]]; then
-    echo "********************************************** WARNING *************************************"
-    echo "*                                                                                          *"
-    echo "*    Perl was compiled with $PERL_CC,"
-    echo "*    which is different than $GCC."
-    echo "*    This may cause significant problems.                                                  *"
-    echo "*                                                                                          *"
-    echo "* Press CTRL^C to stop the build now...                                                    *"
-    echo "********************************************************************************************"
-    sleep 3
 fi
 
 which yasm > /dev/null
@@ -452,10 +429,27 @@ if [ "$PERL_BIN" = "" -o "$CUSTOM_PERL" != "" ]; then
 
 fi
 
+# We have found Perl, so get system arch, stripping out extra -gnu on Linux
+ARCH=`$PERL_BIN -MConfig -le 'print $Config{archname}' | sed 's/gnu-//' | sed 's/^i[3456]86-/i386-/' | sed 's/armv.*?-/arm-/' `
+# Check to make sure this script and perl use the same compiler
+PERL_CC=`$PERL_BIN -V | grep cc=\' | sed "s#.*cc=\'##g" | sed "s#\'.*##g"`
+
+if [[ "$PERL_CC" != "$GCC" ]]; then
+    echo "********************************************** WARNING *************************************"
+    echo "*                                                                                          *"
+    echo "*    Perl was compiled with $PERL_CC,"
+    echo "*    which is different than $GCC."
+    echo "*    This may cause significant problems.                                                  *"
+    echo "*                                                                                          *"
+    echo "* Press CTRL^C to stop the build now...                                                    *"
+    echo "********************************************************************************************"
+    sleep 3
+fi
+
+echo "Building for $OS / $ARCH"
 echo "Building with Perl 5.$PERL_MINOR_VER at $PERL_BIN"
 PERL_BASE=$BUILD/5.$PERL_MINOR_VER
 PERL_ARCH=$BUILD/arch/5.$PERL_MINOR_VER
-
 
 # FreeBSD's make sucks
 if [ "$OS" = "FreeBSD" ]; then
@@ -1558,10 +1552,6 @@ find $BUILD -name '*.packlist' -exec rm -f {} \;
 
 # create our directory structure
 # rsync is used to avoid copying non-binary modules or other extra stuff
-if [ $PERL_MINOR_VER -ge 12 ]; then
-    # Check for Perl using use64bitint and add -64int
-    ARCH=`$PERL_BIN -MConfig -le 'print $Config{archname}' | sed 's/gnu-//' | sed 's/^i[3456]86-/i386-/' | sed 's/armv.*?-/arm-/' `
-fi
 mkdir -p $PERL_ARCH/$ARCH
 rsync -amv --include='*/' --include='*.so' --include='*.bundle' --include='autosplit.ix' --include='*.pm' --include='*.al' --exclude='*' $PERL_BASE/lib/perl5/$ARCH $PERL_ARCH/
 rsync -amv --exclude=$ARCH --include='*/' --include='*.so' --include='*.bundle' --include='autosplit.ix' --include='*.pm' --include='*.al' --exclude='*' $PERL_BASE/lib/perl5/ $PERL_ARCH/$ARCH/

--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -45,6 +45,8 @@ RUN_TESTS=1
 USE_HINTS=1
 CLEAN=1
 FLAGS="-fPIC"
+# Default is to rename every x86 to i386
+RENAME_x86=1
 
 function usage {
     cat <<EOF
@@ -54,6 +56,7 @@ $0 [args] [target]
 -i <lmsbase>  install modules in lmsbase directory
 -p <perlbin > set custom perl binary
 -t            do not run tests
+-r            do not rename all x86 archs to "i386"
 
 target: make target - if not specified all will be built
 
@@ -74,6 +77,9 @@ while getopts hci:p:t opt; do
   t)
       RUN_TESTS=0
       ;;
+  r)
+      RENAME_x86=0
+      ;;
   h)
       usage
       exit
@@ -88,7 +94,7 @@ done
 
 shift $((OPTIND - 1))
 
-echo "RUN_TESTS:$RUN_TESTS CLEAN:$CLEAN USE_HINTS:$USE_HINTS target ${1-all}"
+echo "RUN_TESTS:$RUN_TESTS CLEAN:$CLEAN USE_HINTS:$USE_HINTS RENAME_x86:$RENAME_x86 target ${1-all}"
 
 OS=`uname`
 MACHINE=`uname -m`
@@ -452,7 +458,12 @@ if [ "$PERL_BIN" = "" -o "$CUSTOM_PERL" != "" ]; then
 fi
 
 # We have found Perl, so get system arch, stripping out extra -gnu on Linux
-ARCH=`$PERL_BIN -MConfig -le 'print $Config{archname}' | sed 's/gnu-//' | sed 's/^i[3456]86-/i386-/' | sed 's/armv.*?-/arm-/' `
+ARCH=`$PERL_BIN -MConfig -le 'print $Config{archname}' | sed 's/gnu-//' | sed 's/armv.*?-/arm-/' `
+# Default behavior is to rename all x86 architectures to i386
+if [ $RENAME_x86 -eq 1 ]; then
+   ARCH=`echo "$ARCH" | sed 's/^i[3456]86-/i386-/'`
+fi
+
 # Check to make sure this script and perl use the same compiler
 PERL_CC=`$PERL_BIN -V | grep cc=\' | sed "s#.*cc=\'##g" | sed "s#\'.*##g"`
 

--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -133,7 +133,7 @@ if [ "$OS" = "FreeBSD" ]; then
     fi
 fi
 
-for i in $GCC cpp rsync make ; do
+for i in $GCC $GPP rsync make ; do
     which $i > /dev/null
     if [ $? -ne 0 ] ; then
         echo "$i not found - please install it"


### PR DESCRIPTION
This PR encompasses 4 commits.

1. The code was refactored to use PERL_BIN, rather than ARCHPERL. This required defining ARCH earlier, rather than after the build completed. It also required inverting the logic for the OS test, and moving the PERL_CC tests later.
2. An unreported bug was fixed: the dependency tests checked for cpp, instead of $GPP.
3. Code was refactored to move all dependency checks to the same location within the script.
4. Added new script knob to allow users with certain architectures (i686-linux, for example) to prevent the build script from renaming to i386-linux.

Closes #2.