### PR TITLE
fix: Correct cpp test to use $GPP instead.

### DIFF
--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -133,7 +133,7 @@ if [ "$OS" = "FreeBSD" ]; then
     fi
 fi
 
-for i in $GCC cpp rsync make ; do
+for i in $GCC $GPP rsync make ; do
     which $i > /dev/null
     if [ $? -ne 0 ] ; then
         echo "$i not found - please install it"


### PR DESCRIPTION
Corrects a regression introduced in cb7e0ad0e, where an explicit test for cpp was used, rather than the generic $GPP variable.