### PR TITLE
(bugfix): Adapt to removal of xlocale.h

### DIFF
--- a/CPAN/README.md
+++ b/CPAN/README.md
@@ -23,7 +23,10 @@ On Debian, Ubuntu etc. make sure you have the following packages installed:
 * libgd-dev
 * libmodule-install-perl
 
-In addition you should make sure you do have `/usr/include/xlocale.h` available on your system. If you don't, then simply symlink locale.h:
-```
-sudo ln -s /usr/include/locale.h /usr/include/xlocale.h
-```
+### Preparation of a FreeBSD based system
+On FreeBSD, FreeNAS, etc. make sure you have the following packages/ports installed:
+* devel/nasm
+* shells/bash
+* devel/gmake
+* net/rsync
+* lang/perl5 (or perl5.22 or perl5.26)

--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -655,6 +655,8 @@ function build {
             if [ ! -f build/lib/libicudata_s.a ]; then
                 tar_wrapper zxvf icu4c-58_2-src.tgz
                 cd icu/source
+                # Need to patch ICU to adapt to removal of xlocale.h on some platforms.
+                patch -p0 < ../../icu58_patches/digitlst.cpp.patch
                 . ../../update-config.sh
                 if [ "$OS" = 'Darwin' ]; then
                     ICUFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -DU_USING_ICU_NAMESPACE=0 -DU_CHARSET_IS_UTF8=1" # faster code for native UTF-8 systems

--- a/CPAN/icu58_patches/digitlst.cpp.patch
+++ b/CPAN/icu58_patches/digitlst.cpp.patch
@@ -14,3 +14,28 @@
  # endif
  #endif
  
+--- configure.ac.orig	2018-02-18 21:30:31.573268000 +0000
++++ configure.ac	2018-02-18 21:31:30.974595000 +0000
+@@ -893,11 +893,18 @@
+ AC_CHECK_FUNC(strtod_l)
+ if test x$ac_cv_func_strtod_l = xyes
+ then
+-     CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=1"
+-     U_HAVE_STRTOD_L=1
++    U_HAVE_STRTOD_L=1
++    AC_CHECK_HEADER(xlocale.h)
++    if test "$ac_cv_header_xlocale_h" = yes; then
++      U_HAVE_XLOCALE_H=1
++      CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=1 -DU_HAVE_XLOCALE_H=1"
++    else
++      U_HAVE_XLOCALE_H=0
++      CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=1 -DU_HAVE_XLOCALE_H=0"
++    fi
+ else
+-     CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=0"
+-     U_HAVE_STRTOD_L=0
++    CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=0"
++    U_HAVE_STRTOD_L=0
+ fi
+ AC_SUBST(U_HAVE_STRTOD_L)
+ 

--- a/CPAN/icu58_patches/digitlst.cpp.patch
+++ b/CPAN/icu58_patches/digitlst.cpp.patch
@@ -1,0 +1,16 @@
+--- i18n/digitlst.cpp.orig	2016-10-27 01:37:56.000000000 +0000
++++ i18n/digitlst.cpp	2018-02-18 19:00:07.315169000 +0000
+@@ -61,10 +61,10 @@
+ #endif
+ 
+ #if U_USE_STRTOD_L
+-# if U_PLATFORM_USES_ONLY_WIN32_API || U_PLATFORM == U_PF_CYGWIN
+-#   include <locale.h>
+-# else
++# if U_HAVE_XLOCALE_H
+ #   include <xlocale.h>
++# else
++#   include <locale.h>
+ # endif
+ #endif
+ 


### PR DESCRIPTION
Patch ICU to permit compilation on some platforms with updated glibc. Remove
instruction regarding symlink from README.