### PR TITLE
(bugfix): Retain Perl's archname for use with rsync

### DIFF
--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -435,8 +435,10 @@ if [ "$PERL_BIN" = "" -o "$CUSTOM_PERL" != "" ]; then
 
 fi
 
-# We have found Perl, so get system arch, stripping out extra -gnu on Linux
-ARCH=`$PERL_BIN -MConfig -le 'print $Config{archname}' | sed 's/gnu-//' | sed 's/^i[3456]86-/i386-/' | sed 's/armv.*?-/arm-/' `
+# We have found Perl, so get system arch, according to Perl
+RAW_ARCH=`$PERL_BIN -MConfig -le 'print $Config{archname}'`
+# Strip out extra -gnu on Linux for use within this build script
+ARCH=`echo $RAW_ARCH | sed 's/gnu-//' | sed 's/^i[3456]86-/i386-/' | sed 's/armv.*?-/arm-/' `
 # Check to make sure this script and perl use the same compiler
 PERL_CC=`$PERL_BIN -V | grep "cc='" | sed "s#.*cc='##g" | sed "s#'.*##g"`
 
@@ -1559,8 +1561,8 @@ find $BUILD -name '*.packlist' -exec rm -f {} \;
 # create our directory structure
 # rsync is used to avoid copying non-binary modules or other extra stuff
 mkdir -p $PERL_ARCH/$ARCH
-rsync -amv --include='*/' --include='*.so' --include='*.bundle' --include='autosplit.ix' --include='*.pm' --include='*.al' --exclude='*' $PERL_BASE/lib/perl5/$ARCH $PERL_ARCH/
-rsync -amv --exclude=$ARCH --include='*/' --include='*.so' --include='*.bundle' --include='autosplit.ix' --include='*.pm' --include='*.al' --exclude='*' $PERL_BASE/lib/perl5/ $PERL_ARCH/$ARCH/
+rsync -amv --include='*/' --include='*.so' --include='*.bundle' --include='autosplit.ix' --include='*.pm' --include='*.al' --exclude='*' $PERL_BASE/lib/perl5/$RAW_ARCH $PERL_ARCH/
+rsync -amv --exclude=$RAW_ARCH --include='*/' --include='*.so' --include='*.bundle' --include='autosplit.ix' --include='*.pm' --include='*.al' --exclude='*' $PERL_BASE/lib/perl5/ $PERL_ARCH/$ARCH/
 
 if [ $LMSBASEDIR ]; then
     if [ ! -d $LMSBASEDIR/CPAN/arch/5.$PERL_MINOR_VER/$ARCH ]; then


### PR DESCRIPTION
On Ubuntu 17.10 amd64, the first rsync statement errors out: 
```
rsync: change_dir: "..build/5.26/lib/perl5/x86_64-linux-thread-multi"
failed: No such file or directory (2)
```
This error occurs because the directory in perl5/lib is actually named x86_64-linux-gnu-thread-multi, but the script sanitizes the value prior to storage in ARCH. 

This PR adds a new variable to store Perl's archname value before the sed filters to sanitize out the extra -gnu, -arm, etc. Then, replace sanitized arch value with raw arch within the rsync statements to match the directory name within perl5/lib.

Fixes a regression introduced in #36 . 