### PR TITLE
Debian Perl 5.24 - Override its default "dotless @INC" behaviour

### DIFF
--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -876,7 +876,8 @@ function build {
 
         YAML::LibYAML)
             # Needed because LibYAML 0.35 used . in @INC (not permitted in Perl 5.26)
-            if [ $PERL_MINOR_VER -ge 26 ]; then
+            # Needed for Debian's Perl 5.24 as well, for the same reason
+            if [ $PERL_MINOR_VER -ge 24 ]; then
                 build_module YAML-LibYAML-0.65
             elif [ $PERL_MINOR_VER -ge 16 ]; then
                 build_module YAML-LibYAML-0.35 "" 0


### PR DESCRIPTION
Debian's Perl 5.24, included in the Stretch release (Debian 9),
implements a "dotless @INC", with effect similar to that adopted by
Perl 5.26. One immediate effect is that YAML-LibYAML-0.35 fails to
build under Debian's Perl 5.24.

This behaviour can be suppressed by setting PERL_USE_UNSAFE_INC=1,
as with Perl 5.26.

As this is a cross-platform script, it seems sensible to have Debian's
Perl 5.24 behave the same as a 'regular' Perl 5.24, thereby eliminating
one potential source of frustration in the future.

This change achieves that as follows:

Identifies a Perl 5.24 which doesn't have "." as the last member of
its @INC. If so, sets PERL_USE_UNSAFE_INC=1 for the duration of the
buildme.sh script.

Refer:
https://www.debian.org/releases/stable/amd64/release-notes/ch-information.en.html#perl
"Perl changes that may break third-party software"

Debian's implementation of this feature takes place through a
sitecustomize.pl script.