### PR TITLE
Linux - Check for required header files as well as libs

### DIFF
--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -225,6 +225,13 @@ if [ "$OS" = "Linux" ]; then
 	        exit 1
 	    fi
 	done
+	for hdr in "zlib.h"; do
+	    hdr_found=$(find /usr/include -name "$hdr");
+	    if [ ! "$hdr_found" ]; then
+	        echo "$hdr not found - please install appropriate development package"
+	        exit 1
+	    fi
+	done
 fi
 
 if [ "$OS" = "FreeBSD" ]; then
@@ -233,6 +240,13 @@ if [ "$OS" = "FreeBSD" ]; then
 	    ldconfig -r | grep "${i}.so" > /dev/null #On FreeBSD flag -r should be used, there is no -p
 	    if [ $? -ne 0 ] ; then
 	        echo "$i not found - please install it"
+	        exit 1
+	    fi
+	done
+	for hdr in "zlib.h"; do
+	    hdr_found=$(find /usr/include -name "$hdr");
+	    if [ ! "$hdr_found" ]; then
+	        echo "$hdr not found - please install appropriate development package"
 	        exit 1
 	    fi
 	done


### PR DESCRIPTION
Add a check for zlib's header files as well as the library file.

These are not routinely present on, for example, a Debian system, and
the build will fail without them.

This is not intended to be an exhaustive search, just a look inside
/usr/include. It should cover most cases.