### PR TITLE
Perl 5.24 - Upgrade YAML::LibYAML to v0.65 - Because Debian...

### DIFF
--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -876,7 +876,8 @@ function build {
 
         YAML::LibYAML)
             # Needed because LibYAML 0.35 used . in @INC (not permitted in Perl 5.26)
-            if [ $PERL_MINOR_VER -ge 26 ]; then
+            # Needed for Debian's Perl 5.24 as well, for the same reason
+            if [ $PERL_MINOR_VER -ge 24 ]; then
                 build_module YAML-LibYAML-0.65
             elif [ $PERL_MINOR_VER -ge 16 ]; then
                 build_module YAML-LibYAML-0.35 "" 0


### PR DESCRIPTION
Debian's Perl 5.24, included in the Stretch release (Debian 9),
implements a "dotless @INC", with effect similar to that adopted by
Perl 5.26. One immediate effect is that YAML-LibYAML-0.35 fails to
build under Debian's flavour of Perl 5.24.

The issue has already been resolved for Perl 5.26 by upgrading to
YAML-LibYAML-0.65. This change extends that fix to include Perl 5.24.

This pull request supersedes: https://github.com/Logitech/slimserver-vendor/pull/46


Further information on Debian's Perl 5.24 may be found here:
https://www.debian.org/releases/stable/amd64/release-notes/ch-information.en.html#perl
"Perl changes that may break third-party software"
