### PR TITLE
buildme.sh - A few tidy ups to the 'build' function

### DIFF
--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -910,8 +910,8 @@ function build {
             cp -Rv ../hints ./xs
             cd ..
 
-            $MAKE # minor test failure, so don't test
-            build_module Template-Toolkit-2.21 "INSTALL_BASE=$PERL_BASE TT_ACCEPT=y TT_EXAMPLES=n TT_EXTRAS=n" 0
+            # minor test failure, so don't test
+            build_module Template-Toolkit-2.21 "TT_ACCEPT=y TT_EXAMPLES=n TT_EXTRAS=n" 0
 
             ;;
 
@@ -944,7 +944,7 @@ function build {
             cp $BUILD/lib/mysql/libmysqlclient.a mysql-static
             cd ..
 
-            build_module DBD-mysql-3.0002 "--mysql_config=$BUILD/bin/mysql_config --libs=\"-Lmysql-static -lmysqlclient -lz -lm\" INSTALL_BASE=$PERL_BASE"
+            build_module DBD-mysql-3.0002 "--mysql_config=$BUILD/bin/mysql_config --libs=\"-Lmysql-static -lmysqlclient -lz -lm\""
 
             ;;
 
@@ -981,7 +981,7 @@ function build {
 
             cd ..
 
-            build_module XML-Parser-2.41 "INSTALL_BASE=$PERL_BASE EXPATLIBPATH=$BUILD/lib EXPATINCPATH=$BUILD/include"
+            build_module XML-Parser-2.41 "EXPATLIBPATH=$BUILD/lib EXPATINCPATH=$BUILD/include"
 
             rm -rf expat-2.0.1
             ;;

--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -804,20 +804,10 @@ function build {
             build_libpng
             build_giflib
 
-            # build Image::Scale
             build_module Test-NoWarnings-1.02 "" 0
-
-            tar_wrapper zxvf Image-Scale-0.14.tar.gz
-            cd Image-Scale-0.14
-
-            cp -Rv ../hints .
-            cd ..
-
             build_module Image-Scale-0.14 "--with-jpeg-includes="$BUILD/include" --with-jpeg-static \
                     --with-png-includes="$BUILD/include" --with-png-static \
-                    --with-gif-includes="$BUILD/include" --with-gif-static \
-                    INSTALL_BASE=$PERL_BASE"
-
+                    --with-gif-includes="$BUILD/include" --with-gif-static"
             ;;
 
         IO::AIO)


### PR DESCRIPTION
Here are two proposed commits that tidy up and simplify the `build` function, with the objective of improving readability and consistency (in a small way).

Checked on Debian Perl 5.24 & OSX Perl 5.18, works as expected.

- Image::Scale

There’s no need to untar & apply hints here, as this will be done for us by `build_module`.
One change to existing logic: hints will now only be applied if ‘USE_HINTS’ remains at its default of ‘1’. This is consistent with the treatment of other modules.

- Extraneous arguments to `build_module`

`build_module` already sets up `INSTALL_BASE=$PERL_BASE`, so having these build incantations do it is redundant. Also, remove an extraneous `$MAKE`.
