### PR TITLE
DBI & DBD::SQLite - Tidy up buildme.sh & re-enable tests

### DIFF
--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -573,7 +573,8 @@ function build_all {
     build Class::C3::XS
     build Class::XSAccessor
     build Compress::Raw::Zlib
-    build DBI
+    # DBD::SQLite builds DBI, so don't need it here as well.
+#   build DBI
 #   build DBD::mysql
     build DBD::SQLite
     build Digest::SHA1
@@ -653,16 +654,14 @@ function build {
             if [ $PERL_MINOR_VER -ge 18 ]; then
                 build_module DBI-1.628
             else
-                build_module DBI-1.616 "" 0
+                build_module DBI-1.616
             fi
             ;;
 
         DBD::SQLite)
-            if [ $PERL_MINOR_VER -ge 18 ]; then
-                build_module DBI-1.628 "" 0
-            else
-                build_module DBI-1.616 "" 0
-            fi
+            # Build DBI before DBD::SQLite so that DBD::SQLite is built
+            # against _our_ DBI, not one already present on the system.
+            build DBI
 
             # build ICU, but only if it doesn't exist in the build dir,
             # because it takes so damn long on slow platforms
@@ -752,11 +751,7 @@ function build {
                 rm -rf DBD-SQLite-1.34_01
             else
                 cd ..
-                if [ $PERL_MINOR_VER -ge 16 ]; then
-                   build_module DBD-SQLite-1.34_01 "" 0
-                else
-		   build_module DBD-SQLite-1.34_01
-		fi
+                build_module DBD-SQLite-1.34_01
             fi
 
             ;;


### PR DESCRIPTION
This proposed change tidies up the build of DBI & DBI::SQLite, and re-enables build tests on these two modules, on the premise that it is a 'good thing' to do this.


- DBI is being built twice by `build_all`

Once directly, and then again when DBD::SQLite is built. At present, a separate build incantation is used in each case. (Implemented by Andy Grundman some years ago).

This change stops `build_all` from building DBI, 'formally' assigning the responsibility to the build of DBD::SQLite.

A reminder has been added to the effect that DBD::Sqlite references DBI during its own build process, so we should build DBI first. Thereby avoiding any issue that may arise should DBD::SQLite be built against a version of DBI that is already installed on the system.

- Re-enable testing on DBI-1.616 (installed for Perl <= 5.16).

Testing was turned off in 2017. One very small element of:
‘Upgrade ICU to 58.2, necessary collation and build patches’ https://github.com/Logitech/slimserver-vendor/commit/cb7e0a

This appears to have replicated the approach adopted by the, then existing, DBD::SQLite build of DBI. But testing wasn’t needed there. So re-enabling here.

- Re-enable testing on DBD::SQLite

Testing was originally turned off for Perl 5.16 in 2013. Refer:
‘Add support for building modules for Perl 5.16’ https://github.com/Logitech/slimserver-vendor/commit/6b67d4

However, tests are now known to succeed on:
  Debian Perl 5.24
  OSX 10.12 - The system Perl 5.16 & Perl 5.18, and Homebrew Perl 5.26.

Therefore re-enabling tests on all Perls.

