### PR TITLE
Bugfix/compiler mismatch

### DIFF
--- a/CPAN/README.md
+++ b/CPAN/README.md
@@ -30,3 +30,7 @@ On FreeBSD, FreeNAS, etc. make sure you have the following packages/ports instal
 * devel/gmake
 * net/rsync
 * lang/perl5 (or perl5.22 or perl5.26)
+
+In addition, you should make sure that your Perl was compiled with the same family of compiler 
+(gcc or clang) as you are attempting to use with buildme.sh. Compiler mismatches can cause 
+signficant problems.

--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -439,20 +439,6 @@ fi
 RAW_ARCH=`$PERL_BIN -MConfig -le 'print $Config{archname}'`
 # Strip out extra -gnu on Linux for use within this build script
 ARCH=`echo $RAW_ARCH | sed 's/gnu-//' | sed 's/^i[3456]86-/i386-/' | sed 's/armv.*?-/arm-/' `
-# Check to make sure this script and perl use the same compiler
-PERL_CC=`$PERL_BIN -V | grep "cc='" | sed "s#.*cc='##g" | sed "s#'.*##g"`
-
-if [[ "$PERL_CC" != "$GCC" ]]; then
-    echo "********************************************** WARNING *************************************"
-    echo "*                                                                                          *"
-    echo "*    Perl was compiled with $PERL_CC,"
-    echo "*    which is different than $GCC."
-    echo "*    This may cause significant problems.                                                  *"
-    echo "*                                                                                          *"
-    echo "* Press CTRL^C to stop the build now...                                                    *"
-    echo "********************************************************************************************"
-    sleep 3
-fi
 
 echo "Building for $OS / $ARCH"
 echo "Building with Perl 5.$PERL_MINOR_VER at $PERL_BIN"


### PR DESCRIPTION
The Perl compiler and the one specified for use by buildme.sh *should* be the same. However, this warning is basically useless, as it simply uses the filename of the compiler for comparison. Move the warning to the README, and stop bothering 99% of users.

Fixes #44.