### PR TITLE
(doc): Correct path example in README

### DIFF
--- a/CPAN/README.md
+++ b/CPAN/README.md
@@ -8,7 +8,7 @@ In most cases it should be good enough to just run `./buildme.sh` from this fold
 Once compilation is done, copy the folder in `build/arch/{Perl version}/{your architecture string}/auto/` to the corresponding folder in the Logitech Media Server `CPAN` folder. Eg. from this CPAN folder:
 
 ```
-cp -r build/arch/5.26/aarch64-linux-thread-multi/aarch64-linux-gnu-thread-multi /path/to/slimserver/CPAN/arch/5.26/
+cp -r build/arch/5.26/aarch64-linux-thread-multi /path/to/slimserver/CPAN/arch/5.26/
 ```
 
 ### Preparation of a Debian based system

--- a/CPAN/README.md
+++ b/CPAN/README.md
@@ -5,7 +5,7 @@ Building Perl binaries for Logitech Media Server
 
 In most cases it should be good enough to just run `./buildme.sh` from this folder.
 
-Once compilation is done, copy the folder in `build/arch/{Perl version}/{your architecture string}/auto/` to the corresponding folder in the Logitech Media Server `CPAN` folder. Eg. from this CPAN folder:
+Once compilation is done, copy the folder in `build/arch/{Perl version}/{your architecture string}/` to the corresponding folder in the Logitech Media Server `CPAN` folder. Eg. from this CPAN folder:
 
 ```
 cp -r build/arch/5.26/aarch64-linux-thread-multi /path/to/slimserver/CPAN/arch/5.26/


### PR DESCRIPTION
Starting with 9a2b307, the Perl modules and .pms no longer use nested
arch directories.