### PR TITLE
Quieten tar - 'spams' STDERR on MacOS

### DIFF
--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -492,7 +492,7 @@ mkdir -p $PERL_ARCH
 # $2 = file
 function tar_wrapper {
     echo "tar $1 $2"
-    tar $1 "$2" > /dev/null
+    tar $1 "$2"
     echo "tar done"
 }
 
@@ -519,7 +519,7 @@ function build_module {
             exit
         fi
 
-        tar_wrapper zxvf "${module}.tar.gz"
+        tar_wrapper zxf "${module}.tar.gz"
     fi
 
     cd "${module}"
@@ -591,7 +591,7 @@ function build {
     case "$1" in
         Class::C3::XS)
             if [ $PERL_MINOR_VER -eq 8 ]; then
-                tar_wrapper zxvf Class-C3-XS-0.11.tar.gz
+                tar_wrapper zxf Class-C3-XS-0.11.tar.gz
                 cd Class-C3-XS-0.11
                 patch -p0 < ../Class-C3-XS-no-ckWARN.patch
                 cp -Rv ../hints .
@@ -654,7 +654,7 @@ function build {
             # build ICU, but only if it doesn't exist in the build dir,
             # because it takes so damn long on slow platforms
             if [ ! -f build/lib/libicudata_s.a ]; then
-                tar_wrapper zxvf icu4c-58_2-src.tgz
+                tar_wrapper zxf icu4c-58_2-src.tgz
                 cd icu/source
                 # Need to patch ICU to adapt to removal of xlocale.h on some platforms.
                 patch -p0 < ../../icu58_patches/digitlst.cpp.patch
@@ -703,7 +703,7 @@ function build {
             cp -v icudt58*.dat $BUILD/share/icu/58.2
 
             # Custom build for ICU support
-            tar_wrapper zxvf DBD-SQLite-1.34_01.tar.gz
+            tar_wrapper zxf DBD-SQLite-1.34_01.tar.gz
             cd DBD-SQLite-1.34_01
             if [[ "$GCC_LIBCPP" == true ]] ; then
             # Need this because GLIBCXX uses -lstdc++, but LIBCPP uses -lc++
@@ -756,7 +756,7 @@ function build {
             # custom build to apply pthread patch
             export PERL_MM_USE_DEFAULT=1
 
-            tar_wrapper zxvf EV-4.03.tar.gz
+            tar_wrapper zxf EV-4.03.tar.gz
             cd EV-4.03
             patch -p0 < ../EV-llvm-workaround.patch # patch to avoid LLVM bug 9891
             if [ "$OS" = "Darwin" ]; then
@@ -817,14 +817,14 @@ function build {
             build_module Test-NoWarnings-1.02 "" 0
             build_module Net-IDN-Encode-2.400
 
-            tar_wrapper zxvf Net-SSLeay-1.82.tar.gz
+            tar_wrapper zxf Net-SSLeay-1.82.tar.gz
             cd Net-SSLeay-1.82
             patch -p0 < ../NetSSLeay-SunOS-NoPrompt.patch
             cd ..
 
             build_module Net-SSLeay-1.82
 
-            tar_wrapper zxvf IO-Socket-SSL-2.052.tar.gz
+            tar_wrapper zxf IO-Socket-SSL-2.052.tar.gz
             cd IO-Socket-SSL-2.052
             patch -p0 < ../IOSocketSSL-NoPrompt-SunOS.patch
             cd ..
@@ -889,7 +889,7 @@ function build {
 
         Template)
             # Template, custom build due to 2 Makefile.PL's
-            tar_wrapper zxvf Template-Toolkit-2.21.tar.gz
+            tar_wrapper zxf Template-Toolkit-2.21.tar.gz
             cd Template-Toolkit-2.21
             cp -Rv ../hints .
             cp -Rv ../hints ./xs
@@ -902,7 +902,7 @@ function build {
 
         DBD::mysql)
             # Build libmysqlclient
-            tar_wrapper jxvf mysql-5.1.37.tar.bz2
+            tar_wrapper jxf mysql-5.1.37.tar.bz2
             cd mysql-5.1.37
             . ../update-config.sh
             CC=gcc CXX=gcc \
@@ -922,7 +922,7 @@ function build {
             rm -rf mysql-5.1.37
 
             # DBD::mysql custom, statically linked with libmysqlclient
-            tar_wrapper zxvf DBD-mysql-3.0002.tar.gz
+            tar_wrapper zxf DBD-mysql-3.0002.tar.gz
             cd DBD-mysql-3.0002
             cp -Rv ../hints .
             mkdir mysql-static
@@ -935,7 +935,7 @@ function build {
 
         XML::Parser)
             # build expat
-            tar_wrapper zxvf expat-2.0.1.tar.gz
+            tar_wrapper zxf expat-2.0.1.tar.gz
             cd expat-2.0.1/conftools
             . ../../update-config.sh
             cd ..
@@ -958,7 +958,7 @@ function build {
             cd ../..
 
             # XML::Parser custom, built against expat
-            tar_wrapper zxvf XML-Parser-2.41.tar.gz
+            tar_wrapper zxf XML-Parser-2.41.tar.gz
             cd XML-Parser-2.41
             cp -Rv ../hints .
             cp -Rv ../hints ./Expat # needed for second Makefile.PL
@@ -973,7 +973,7 @@ function build {
 
         Font::FreeType)
             # build freetype
-            tar_wrapper zxvf freetype-2.4.2.tar.gz
+            tar_wrapper zxf freetype-2.4.2.tar.gz
             cd freetype-2.4.2
             . ../update-config.sh
 
@@ -1003,7 +1003,7 @@ function build {
             ln -sf libfreetype.a libfreetype_s.a
             cd ../..
 
-            tar_wrapper zxvf Font-FreeType-0.03.tar.gz
+            tar_wrapper zxf Font-FreeType-0.03.tar.gz
             cd Font-FreeType-0.03
 
             # Build statically
@@ -1031,7 +1031,7 @@ function build {
             # build libmediascan
             # XXX library does not link correctly on Darwin with libjpeg due to missing x86_64
             # in libjpeg.dylib, Perl still links OK because it uses libjpeg.a
-            tar_wrapper zxvf libmediascan-0.1.tar.gz
+            tar_wrapper zxf libmediascan-0.1.tar.gz
 
             if [ "$OSX_VER" = "10.9" -o "$OSX_VER" = "10.10" ]; then
                 patch -p0 libmediascan-0.1/bindings/perl/hints/darwin.pl < libmediascan-hints-darwin.pl.patch
@@ -1103,7 +1103,7 @@ function build_libexif {
     fi
 
     # build libexif
-    tar_wrapper jxvf libexif-0.6.20.tar.bz2
+    tar_wrapper jxf libexif-0.6.20.tar.bz2
     cd libexif-0.6.20
     . ../update-config.sh
 
@@ -1132,7 +1132,7 @@ function build_libjpeg {
     # skip on 10.9 until we've been able to build nasm from macports
     if [ "$OS" = "Darwin" -a "$OSX_VER" != "10.5" ]; then
         # Build i386/x86_64 versions of turbo
-        tar_wrapper zxvf libjpeg-turbo-1.1.1.tar.gz
+        tar_wrapper zxf libjpeg-turbo-1.1.1.tar.gz
         cd libjpeg-turbo-1.1.1
 
         # Disable features we don't need
@@ -1179,7 +1179,7 @@ function build_libjpeg {
         # combine i386 turbo with ppc libjpeg
 
         # build i386 turbo
-        tar_wrapper zxvf libjpeg-turbo-1.1.1.tar.gz
+        tar_wrapper zxf libjpeg-turbo-1.1.1.tar.gz
         cd libjpeg-turbo-1.1.1
 
         # Disable features we don't need
@@ -1200,7 +1200,7 @@ function build_libjpeg {
         cd ..
 
         # build ppc libjpeg 6b
-        tar_wrapper zxvf jpegsrc.v6b.tar.gz
+        tar_wrapper zxf jpegsrc.v6b.tar.gz
         cd jpeg-6b
 
         # Disable features we don't need
@@ -1227,7 +1227,7 @@ function build_libjpeg {
 
     elif [ "$ARCH" = "i386-linux-thread-multi" -o "$ARCH" = "x86_64-linux-thread-multi" -o "$ARCH" = "i86pc-solaris-thread-multi-64int" -o "$OS" = "FreeBSD" ]; then
         # build libjpeg-turbo
-        tar_wrapper zxvf libjpeg-turbo-1.1.1.tar.gz
+        tar_wrapper zxf libjpeg-turbo-1.1.1.tar.gz
         cd libjpeg-turbo-1.1.1
 
         # Disable features we don't need
@@ -1247,7 +1247,7 @@ function build_libjpeg {
 
     # build libjpeg v8 on other platforms
     else
-        tar_wrapper zxvf jpegsrc.v8b.tar.gz
+        tar_wrapper zxf jpegsrc.v8b.tar.gz
         cd jpeg-8b
         . ../update-config.sh
         # Disable features we don't need
@@ -1278,7 +1278,7 @@ function build_libpng {
     fi
 
     # build libpng
-    tar_wrapper zxvf libpng-1.4.3.tar.gz
+    tar_wrapper zxf libpng-1.4.3.tar.gz
     cd libpng-1.4.3
 
     # Disable features we don't need
@@ -1307,7 +1307,7 @@ function build_giflib {
     fi
 
     # build giflib
-    tar_wrapper zxvf giflib-4.1.6.tar.gz
+    tar_wrapper zxf giflib-4.1.6.tar.gz
     cd giflib-4.1.6
     . ../update-config.sh
     CC="$GCC" CXX="$GXX" CPP="$GPP" \
@@ -1334,7 +1334,7 @@ function build_ffmpeg {
     fi
 
     # build ffmpeg, enabling only the things libmediascan uses
-    tar_wrapper jxvf ffmpeg-0.8.4.tar.bz2
+    tar_wrapper jxf ffmpeg-0.8.4.tar.bz2
     cd ffmpeg-0.8.4
     . ../update-config.sh
 
@@ -1494,7 +1494,7 @@ function build_bdb {
     fi
 
     # build bdb
-    tar_wrapper zxvf db-5.1.25.tar.gz
+    tar_wrapper zxf db-5.1.25.tar.gz
     cd db-5.1.25/dist
     . ../../update-config.sh
     cd ../build_unix


### PR DESCRIPTION
At present, `tar` is being called with the verbose flag when archives are unpacked. This generates a listing of the files as they are unpacked, which I don't think isparticularly useful.

GNU tar outputs the listing to STDOUT. The function `tar_wrapper` then throws that straight into `/dev/null`, so it is not seen.

MacOS tar (BSDTAR) outputs the listing to STDERR. This makes for a noisy STDERR and interferes with the normal flow of build error/warning messages.

This proposed change quietens matters by removing the verbose flag from tar invocations. tar_wrapper's STDOUT redirection then becomes unnecessary, so it is removed.