### PR TITLE
Improve FreeBSD regex to match only if the line starts with CC=.

### DIFF
--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -106,9 +106,9 @@ if [ "$OS" = "FreeBSD" ]; then
     BSD_MAJOR_VER=`uname -r | sed 's/\..*//g'`
     BSD_MINOR_VER=`uname -r | sed 's/.*\.//g'`
     if [ -f "/etc/make.conf" ]; then
-        MAKE_CC=`grep CC /etc/make.conf | grep -v CCACHE | grep -v \# | sed 's#CC=##g'`
-        MAKE_CXX=`grep CXX /etc/make.conf | grep -v CCACHE | grep -v \# | sed 's#CXX=##g'`
-        MAKE_CPP=`grep CPP /etc/make.conf | grep -v CCACHE | grep -v \# | sed 's#CPP=##g'`
+        MAKE_CC=`grep ^CC= /etc/make.conf | grep -v CCACHE | grep -v \# | sed 's#CC=##g'`
+        MAKE_CXX=`grep ^CXX= /etc/make.conf | grep -v CCACHE | grep -v \# | sed 's#CXX=##g'`
+        MAKE_CPP=`grep ^CPP= /etc/make.conf | grep -v CCACHE | grep -v \# | sed 's#CPP=##g'`
     fi
     if [[ ! -z "$MAKE_CC" ]]; then
         GCC="$MAKE_CC"


### PR DESCRIPTION
This is not a perfect fix I think, but at least it's more compatible with having a make.conf now.