### PR TITLE
Finish xlocale removal, fix CPP declarations, other tidy-ups

### DIFF
--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -99,8 +99,21 @@ if [ "$OS" != "Linux" -a "$OS" != "Darwin" -a "$OS" != "FreeBSD" -a "$OS" != "Su
 fi
 
 # Set default values prior to potential overwrite
-GCC=gcc
-GXX=g++
+# Check to see if CC and CXX are already defined
+if [[ ! -z "$CC" ]]; then
+   GCC="$CC"
+else
+   # Take a guess
+   GCC=gcc
+fi
+if [[ ! -z "$CXX" ]]; then
+   GXX="$CXX"
+else
+   GXX=g++
+fi
+
+# FreeBSD uses the following precedence: 1. Environment values for CC/CXX/CPP,
+# 2. Values defined in or 3. Stock build chain.
 if [ "$OS" = "FreeBSD" ]; then
     BSD_MAJOR_VER=`uname -r | sed 's/\..*//g'`
     BSD_MINOR_VER=`uname -r | sed 's/.*\.//g'`
@@ -109,7 +122,9 @@ if [ "$OS" = "FreeBSD" ]; then
         MAKE_CXX=`grep ^CXX= /etc/make.conf | grep -v CCACHE | grep -v \# | sed 's#CXX=##g'`
         MAKE_CPP=`grep ^CPP= /etc/make.conf | grep -v CCACHE | grep -v \# | sed 's#CPP=##g'`
     fi
-    if [[ ! -z "$MAKE_CC" ]]; then
+    if [[ ! -z "$CC" ]]; then
+        GCC="$CC"
+    elif [[ ! -z "$MAKE_CC" ]]; then
         GCC="$MAKE_CC"
     elif [ $BSD_MAJOR_VER -ge 10 ]; then
         # FreeBSD started using clang as the default compiler starting with 10.
@@ -117,7 +132,9 @@ if [ "$OS" = "FreeBSD" ]; then
     else
         GCC=gcc
     fi
-    if [[ ! -z "$MAKE_CXX" ]]; then
+    if [[ ! -z "$CXX" ]]; then
+        GXX="$CXX"
+    elif [[ ! -z "$MAKE_CXX" ]]; then
         GXX="$MAKE_CXX"
     elif [ $BSD_MAJOR_VER -ge 10 ]; then
         # FreeBSD started using clang++ as the default compiler starting with 10.
@@ -125,7 +142,9 @@ if [ "$OS" = "FreeBSD" ]; then
     else
         GXX=g++
     fi
-    if [[ ! -z "$MAKE_CPP" ]]; then
+    if [[ ! -z "$CPP" ]]; then
+        GPP="$CPP"
+    elif [[ ! -z "$MAKE_CPP" ]]; then
         GPP="$MAKE_CPP"
     else
         GPP=cpp

--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -112,8 +112,10 @@ else
    GXX=g++
 fi
 
-# FreeBSD uses the following precedence: 1. Environment values for CC/CXX/CPP,
-# 2. Values defined in or 3. Stock build chain.
+# This script uses the following precedence for FreeBSD:
+# 1. Environment values for CC/CXX/CPP (checks if $CC is already defined)
+# 2. Values defined in /etc/make.conf, or
+# 3. Stock build chain
 if [ "$OS" = "FreeBSD" ]; then
     BSD_MAJOR_VER=`uname -r | sed 's/\..*//g'`
     BSD_MINOR_VER=`uname -r | sed 's/.*\.//g'`

--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -267,7 +267,7 @@ if [ "$OS" = "FreeBSD" ]; then
 	    fi
 	done
 	for hdr in "zlib.h"; do
-	    hdr_found=$(find /usr/include -name "$hdr");
+	    hdr_found=$(find /usr/include/ -name "$hdr");
 	    if [ ! "$hdr_found" ]; then
 	        echo "$hdr not found - please install appropriate development package"
 	        exit 1

--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -1395,12 +1395,16 @@ function build_ffmpeg {
 
     # ASM doesn't work right on x86_64
     # XXX test --arch options on Linux
-    if [ "$ARCH" = "x86_64-linux-thread-multi" -o "$ARCH" = "amd64-freebsd-thread-multi" -o "$ARCH" = "i86pc-solaris-thread-multi-64int" ]; then
+    if [[ "$ARCH" = "x86_64-linux-thread-multi" || "$ARCH" =~ "amd64-freebsd" || "$ARCH" = "i86pc-solaris-thread-multi-64int" ]]; then
         FFOPTS="$FFOPTS --disable-mmx"
     fi
     # FreeBSD amd64 needs arch option
-    if [ "$ARCH" = "amd64-freebsd" -o "$ARCH" = "amd64-freebsd-thread-multi" ]; then
+    if [[ "$ARCH" =~ "amd64-freebsd" ]]; then
         FFOPTS="$FFOPTS --arch=x86"
+        # FFMPEG has known issues with GCC 4.2. See: https://trac.ffmpeg.org/ticket/3970
+        if [[ "$CC_IS_GCC" == true && "$CC_VERSION" -ge 40200 && "$CC_VERSION" -lt 40300 ]]; then
+            FFOPTS="$FFOPTS --disable-asm"
+        fi
     fi
 
     if [ "$OS" = "Darwin" ]; then

--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -795,7 +795,12 @@ function build {
             ;;
 
         Encode::Detect)
-            build_module Data-Dump-1.19
+            if [[ "$OS" == "FreeBSD" && `sysctl -n security.jail.jailed` == 1 && $PERL_MINOR_VER -le 10 ]]; then
+                # Tests fail in jails with old Perl
+                build_module Data-Dump-1.19 "" 0
+            else
+                build_module Data-Dump-1.19
+            fi
             build_module ExtUtils-CBuilder-0.260301
             build_module Module-Build-0.35 "" 0
             build_module Encode-Detect-1.00

--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -664,6 +664,8 @@ function build {
         DBI)
             if [ $PERL_MINOR_VER -ge 18 ]; then
                 build_module DBI-1.628
+            elif [ $PERL_MINOR_VER -eq 8 ]; then
+                build_module DBI-1.616 "" 0
             else
                 build_module DBI-1.616
             fi

--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -98,10 +98,9 @@ if [ "$OS" != "Linux" -a "$OS" != "Darwin" -a "$OS" != "FreeBSD" -a "$OS" != "Su
     exit
 fi
 
-# Set default values prior to potential overwrite for FreeBSD platforms
+# Set default values prior to potential overwrite
 GCC=gcc
 GXX=g++
-GPP=cpp
 if [ "$OS" = "FreeBSD" ]; then
     BSD_MAJOR_VER=`uname -r | sed 's/\..*//g'`
     BSD_MINOR_VER=`uname -r | sed 's/.*\.//g'`
@@ -131,9 +130,14 @@ if [ "$OS" = "FreeBSD" ]; then
     else
         GPP=cpp
     fi
+    # Ensure the environment makes use of the desired/specified compilers and
+    # pre-processor
+    export CC=$GCC
+    export CXX=$GXX
+    export CPP=$GPP
 fi
 
-for i in $GCC $GPP rsync make ; do
+for i in $GCC $GXX rsync make ; do
     which $i > /dev/null
     if [ $? -ne 0 ] ; then
         echo "$i not found - please install it"
@@ -674,7 +678,6 @@ function build {
                     for i in ../../icu58_patches/freebsd/patch-*;
                         do patch -p0 < $i; done
                 fi
-                CC="$GCC" CXX="$GXX" CPP="$GPP" \
                 CFLAGS="$ICUFLAGS" CXXFLAGS="$ICUFLAGS" LDFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS" \
                     ./runConfigureICU $ICUOS --prefix=$BUILD --enable-static --with-data-packaging=archive
                 $MAKE
@@ -939,7 +942,6 @@ function build {
             cd expat-2.0.1/conftools
             . ../../update-config.sh
             cd ..
-            CC="$GCC" CXX="$GXX" CPP="$GPP" \
             CFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS" \
             LDFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS" \
                 ./configure --prefix=$BUILD \
@@ -986,7 +988,6 @@ function build {
             # libfreetype.a size (i386/x86_64 universal binary):
             #   1634288 (default)
             #    461984 (with custom ftoption.h/modules.cfg)
-            CC="$GCC" CXX="$GXX" CPP="$GPP" \
             CFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS" \
             LDFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS" \
                 ./configure --prefix=$BUILD
@@ -1046,7 +1047,6 @@ function build {
             fi
             . ../update-config.sh
 
-            CC="$GCC" CXX="$GXX" CPP="$GPP" \
             CFLAGS="-I$BUILD/include $FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
             LDFLAGS="-L$BUILD/lib $FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
             OBJCFLAGS="-L$BUILD/lib $FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
@@ -1107,7 +1107,6 @@ function build_libexif {
     cd libexif-0.6.20
     . ../update-config.sh
 
-    CC="$GCC" CXX="$GXX" CPP="$GPP" \
     CFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
     LDFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
         ./configure --prefix=$BUILD \
@@ -1233,7 +1232,6 @@ function build_libjpeg {
         # Disable features we don't need
         cp -fv ../libjpeg-turbo-jmorecfg.h jmorecfg.h
 
-        CC="$GCC" CXX="$GXX" CPP="$GPP" \
         CFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS" CXXFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS" LDFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS" \
             ./configure --prefix=$BUILD --disable-dependency-tracking
         $MAKE
@@ -1253,7 +1251,6 @@ function build_libjpeg {
         # Disable features we don't need
         cp -fv ../libjpeg-jmorecfg.h jmorecfg.h
 
-        CC="$GCC" CXX="$GXX" CPP="$GPP" \
         CFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
         LDFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
             ./configure --prefix=$BUILD \
@@ -1285,7 +1282,6 @@ function build_libpng {
     cp -fv ../libpng-pngconf.h pngconf.h
     . ../update-config.sh
 
-    CC="$GCC" CXX="$GXX" CPP="$GPP" \
     CFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
     LDFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
         ./configure --prefix=$BUILD \
@@ -1310,7 +1306,6 @@ function build_giflib {
     tar_wrapper zxf giflib-4.1.6.tar.gz
     cd giflib-4.1.6
     . ../update-config.sh
-    CC="$GCC" CXX="$GXX" CPP="$GPP" \
     CFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
     LDFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
         ./configure --prefix=$BUILD \
@@ -1465,7 +1460,6 @@ function build_ffmpeg {
         FLAGS=$SAVED_FLAGS
         cd ..
     else
-        CC="$GCC" CXX="$GXX" CPP="$GPP" \
         CFLAGS="$FLAGS -O3" \
         LDFLAGS="$FLAGS -O3" \
             ./configure $FFOPTS
@@ -1504,7 +1498,6 @@ function build_bdb {
        patch -p0 < ../db51-src_dbinc_atomic.patch
        popd
     fi
-    CC="$GCC" CXX="$GXX" CPP="$GPP" \
     CFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
     LDFLAGS="$FLAGS $OSX_ARCH $OSX_FLAGS -O3" \
         ../dist/configure --prefix=$BUILD $MUTEX \

--- a/CPAN/icu58_patches/digitlst.cpp.patch
+++ b/CPAN/icu58_patches/digitlst.cpp.patch
@@ -39,3 +39,33 @@
  fi
  AC_SUBST(U_HAVE_STRTOD_L)
  
+--- configure.orig	2016-10-04 19:30:20.000000000 +0000
++++ configure	2018-06-24 01:04:40.476591000 +0000
+@@ -7053,11 +7053,23 @@
+ 
+ if test x$ac_cv_func_strtod_l = xyes
+ then
+-     CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=1"
+-     U_HAVE_STRTOD_L=1
++    U_HAVE_STRTOD_L=1
++    ac_fn_c_check_header_mongrel "$LINENO" "xlocale.h" "ac_cv_header_xlocale_h" "$ac_includes_default"
++if test "x$ac_cv_header_xlocale_h" = xyes; then :
++
++fi
++
++
++    if test "$ac_cv_header_xlocale_h" = yes; then
++      U_HAVE_XLOCALE_H=1
++      CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=1 -DU_HAVE_XLOCALE_H=1"
++    else
++      U_HAVE_XLOCALE_H=0
++      CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=1 -DU_HAVE_XLOCALE_H=0"
++    fi
+ else
+-     CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=0"
+-     U_HAVE_STRTOD_L=0
++    CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=0"
++    U_HAVE_STRTOD_L=0
+ fi
+ 
+ 


### PR DESCRIPTION
This is a proposed set of 8 commits, to address reported issues, and revert recent changes that break the build for old Perls.

1. Fix ICU build on FreeBSD 11.1
The FreeBSD automake doesn't notice/care that the automake.ac file was changed by the previous patch. Fixes #57 .

2. Remove erroneous CC/CXX/CPP declaration
The previous addition of the explicit CPP declaration caused problems on MacOS, so this commit addresses that. Fixes #53 .

3. Detect CC/CXX defined in environment
Add code to use the $CC and $CXX variables in the environment or commandline.

4. Skip tests to enable Data-Dump build with old Perl
The Data::Dump module tests fail in FreeBSD jails and Perl 5.10 and below. 

5. Add trailing slash to enable build.
The 'find' operation to detect the zlib headers fails on old FreeBSD without trailing slash.

6. Skip DBI tests for really old Perl
The re-enabling of tests for DBI in b3e127b introduced a regression, where the build failed with Perl 5.8. 

7. Disable asm for certain gcc, clean FreeBSD arch detect
There are known issues with compiling ffmpeg with gcc 4.2, especially with asm optimizations on amd64 FreeBSD platforms. Disable all asm, and make FreeBSD arch tests more robust.

8. This PR also includes a minor fix to comments describing the CC detection scheme for FreeBSD.
 
This set of commits builds successfully on:

- Centos 7 x86_64 (Perl 5.16.3, gcc 4.8.5)
- Debian 9.5 amd64 (Perl 5.24.1, gcc 6.3.0)
- Debian 9.5 i386 (Perl 5.24.1, gcc 6.3.0)
- Ubuntu 18.04.1 x86_64 (Perl 5.26.1, gcc 7.3.0)
- FreeBSD 11.2 amd64 (5.26.2 & 5.28.0, clang 6.0.0)
- FreeBSD 11.1 amd64 (Perl 5.22.4 & 5.24.4 & 5.26.1, clang 4.0.0)
- FreeBSD 7.2 amd64 (Perl 5.8.9 & 5.10.1 & 5.12.4, gcc 4.2.1)
- FreeBSD 7.2 i386 (Perl 5.8.9 & 5.10.1 & 5.12.4, gcc 4.2.1)