### PR TITLE
Force flac to operate exclusively in the 'C' locale

### DIFF
--- a/flac/02-flac-C-locale.patch
+++ b/flac/02-flac-C-locale.patch
@@ -1,0 +1,89 @@
+From 76505158ddbd2d5ef68ae830d531f9714dc8f936 Mon Sep 17 00:00:00 2001
+From: Martin Williams <martinr.williams@gmail.com>
+Date: Thu, 22 Aug 2019 19:25:50 +0100
+Subject: [PATCH] Force use of 'C' locale, otherwise LMS transcoding breaks
+
+In interpreting the mm:ss.ss 'skip' & 'until' specifications, flac
+versions 1.30+ make use of 'strtod', which applies the conventions of
+the locale currently in force. Which means accepting one of '.' or ','
+as the decimal separator, according to the locale.
+
+If the separator used on the flac command line does not match the
+separator specified by the locale, flac will simply fail, with a message
+of the form 'ERROR: invalid value for skip'.
+
+Logitech Media Server makes use of the 'skip' and 'until' specifiers in
+in some of its transcoding rules. But it uses the '.' convention
+exclusively, without reference to the current locale.
+'Slim::Utils::DateTime::fracSecToMinSec' is responsible for formatting
+the specification.
+
+In consequence, transcoding silently fails on any platform that is not
+set up to use '.' as its decimal separator. Which covers much of the
+world.
+
+This change has flac operate exclusively in the 'C' locale, which
+assures us that the '.' will be recognized as the decimal separator
+regardless of the user's locale settings.
+
+Notes:
+
+1) This patch applies cleanly to the version of flac 1.32+ adopted by
+LMS in September 2018, which is taken from the flac tree headed by
+commit reference faafa4.
+
+Suitable adaptation may be required if another version of flac is used,
+e.g. the (earlier) published flac version 1.32.
+
+2) flac versions prior to 1.30 made use of 'atof', instead of 'strtod'.
+Although 'atof' also uses the current locale, the code in use at that
+time did not fail completely, it simply truncated the 'skip'
+specification to its integer part. LMS transcoding, therefore, works,
+although the seek points would not be accurate to fractions of a second.
+
+Refer flac commit 4b0f270.
+---
+ src/flac/main.c | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/src/flac/main.c b/src/flac/main.c
+index be072a3d..43e912b9 100644
+--- a/src/flac/main.c
++++ b/src/flac/main.c
+@@ -310,6 +310,12 @@ int main(int argc, char *argv[])
+ #endif
+ 
+ 	srand((uint32_t)time(0));
++
++#if 1
++/* LMS patch: Use C locale exclusively */
++	setlocale(LC_ALL, "C"); /* Belt & braces. Should be the default anyway */
++#else
++/* Original code block: Sets up user locale */
+ #ifdef _WIN32
+ 	{
+ 		const char *var;
+@@ -324,6 +330,9 @@ int main(int argc, char *argv[])
+ #else
+ 	setlocale(LC_ALL, "");
+ #endif
++/* Original code block ends */
++#endif
++
+ 	if(!init_options()) {
+ 		flac__utils_printf(stderr, 1, "ERROR: allocating memory\n");
+ 		retval = 1;
+@@ -1170,6 +1179,10 @@ static void usage_header(void)
+ 	printf("Copyright (C) 2000-2009  Josh Coalson\n");
+ 	printf("Copyright (C) 2011-2016  Xiph.Org Foundation\n");
+ 	printf("\n");
++	printf("   Patched for Logitech Media Server:\n");
++	printf("   This version of flac operates exclusively in the 'C'\n");
++	printf("   locale. In particular, '--skip' and '--until' mm:ss.ss\n");
++	printf("   specifications require a '.' as decimal separator.\n\n");
+ 	printf("This program is free software; you can redistribute it and/or\n");
+ 	printf("modify it under the terms of the GNU General Public License\n");
+ 	printf("as published by the Free Software Foundation; either version 2\n");
+-- 
+2.20.1
+

--- a/flac/buildme-crosstool.sh
+++ b/flac/buildme-crosstool.sh
@@ -32,6 +32,10 @@ rm -rf flac-$FLAC
 echo "Most log mesages sent to $LOG... only 'errors' displayed here"
 date > $LOG
 
+# '-O2' reduces binary size with minimal performance loss.
+export CFLAGS="-O2"
+export CXXFLAGS="-O2"
+
 ## Build Ogg first
 echo "Untarring libogg-$OGG.tar.gz..."
 tar -zxf libogg-${OGG}${OGG_GIT}.tar.gz

--- a/flac/buildme-crosstool.sh
+++ b/flac/buildme-crosstool.sh
@@ -47,6 +47,7 @@ echo "Untarring..."
 tar zxvf flac-${FLAC}${FLAC_GIT}.tar.gz >> $LOG
 cd flac-$FLAC >> $LOG
 patch -p1 < ../01-flac.patch >> $LOG
+patch -p1 < ../02-flac-C-locale.patch >> $LOG
 echo "Configuring..."
 ./configure --host=$TARGET --with-ogg-includes=$PWD/../libogg-$OGG/include --with-ogg-libraries=$PWD/../libogg-$OGG/src/.libs/ --disable-doxygen-docs --disable-shared --disable-xmms-plugin --disable-cpplibs --prefix $OUTPUT >> $LOG
 echo "Running make"

--- a/flac/buildme-freebsd.sh
+++ b/flac/buildme-freebsd.sh
@@ -30,6 +30,10 @@ rm -rf flac-$FLAC
 echo "Most log mesages sent to $LOG... only 'errors' displayed here"
 date > $LOG
 
+# '-O2' reduces binary size with minimal performance loss.
+export CFLAGS="-O2"
+export CXXFLAGS="-O2"
+
 ## Build Ogg first
 echo "Untarring libogg-$OGG.tar.gz..."
 tar -zxf libogg-${OGG}${OGG_GIT}.tar.gz

--- a/flac/buildme-freebsd.sh
+++ b/flac/buildme-freebsd.sh
@@ -45,6 +45,7 @@ echo "Untarring..."
 tar zxvf flac-${FLAC}${FLAC_GIT}.tar.gz >> $LOG
 cd flac-$FLAC >> $LOG
 patch -p1 < ../01-flac.patch >> $LOG
+patch -p1 < ../02-flac-C-locale.patch >> $LOG
 mv configure.in configure.ac
 autoreconf -fi
 ./autogen.sh

--- a/flac/buildme-linux.sh
+++ b/flac/buildme-linux.sh
@@ -35,6 +35,7 @@ tar zxvf flac-${FLAC}${FLAC_GIT}.tar.gz >> $LOG
 cd flac-$FLAC >> $LOG
 . ../../CPAN/update-config.sh
 patch -p1 < ../01-flac.patch >> $LOG
+patch -p1 < ../02-flac-C-locale.patch >> $LOG
 echo "Configuring..."
 ./configure --with-ogg-includes=$PWD/../libogg-$OGG/include --with-ogg-libraries=$PWD/../libogg-$OGG/src/.libs/ --disable-doxygen-docs --disable-shared --disable-xmms-plugin --disable-cpplibs --prefix $OUTPUT >> $LOG
 echo "Running make"

--- a/flac/buildme-linux.sh
+++ b/flac/buildme-linux.sh
@@ -18,6 +18,10 @@ rm -rf flac-$FLAC
 echo "Most log mesages sent to $LOG... only 'errors' displayed here"
 date > $LOG
 
+# '-O2' reduces binary size with minimal performance loss.
+export CFLAGS="-O2"
+export CXXFLAGS="-O2"
+
 ## Build Ogg first
 echo "Untarring libogg-$OGG.tar.gz..."
 tar -zxf libogg-${OGG}${OGG_GIT}.tar.gz

--- a/flac/buildme-osx.sh
+++ b/flac/buildme-osx.sh
@@ -10,10 +10,9 @@ ARCH="osx"
 OUTPUT=$PWD/flac-build-$ARCH-$CHANGENO
 
 # Mac Universal Binary support
-#CFLAGS="-isysroot /Developer/SDKs/MacOSX10.4u.sdk -arch i386 -arch ppc -mmacosx-version-min=10.3"
-#LDFLAGS="-arch i386 -arch ppc"
-CFLAGS="-mmacosx-version-min=10.6 -arch x86_64"
-LDFLAGS="-mmacosx-version-min=10.6 -arch x86_64"
+CFLAGS="-O2 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk -arch i386 -arch x86_64 -mmacosx-version-min=10.7"
+CXXFLAGS="${CFLAGS}"
+LDFLAGS="-Wl,-syslibroot,/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk -arch i386 -arch x86_64 -mmacosx-version-min=10.7"
 
 # Clean up
 rm -rf $OUTPUT
@@ -40,7 +39,7 @@ cd flac-$FLAC >> $LOG
 patch -p1 < ../01-flac.patch >> $LOG
 patch -p1 < ../02-flac-C-locale.patch >> $LOG
 echo "Configuring..."
-./configure CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" --with-ogg-includes=$PWD/../libogg-$OGG/include --with-ogg-libraries=$PWD/../libogg-$OGG/src/.libs/ --disable-doxygen-docs --disable-shared --disable-xmms-plugin --disable-dependency-tracking --disable-asm-optimizations --disable-cpplibs --prefix $OUTPUT >> $LOG
+./configure CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" LDFLAGS="$LDFLAGS" --with-ogg-includes=$PWD/../libogg-$OGG/include --with-ogg-libraries=$PWD/../libogg-$OGG/src/.libs/ --disable-doxygen-docs --disable-shared --disable-xmms-plugin --disable-dependency-tracking --disable-asm-optimizations --disable-cpplibs --prefix $OUTPUT >> $LOG
 echo "Running make"
 make >> $LOG
 echo "Running make install"

--- a/flac/buildme-osx.sh
+++ b/flac/buildme-osx.sh
@@ -38,6 +38,7 @@ echo "Untarring..."
 tar zxvf flac-${FLAC}${FLAC_GIT}.tar.gz >> $LOG
 cd flac-$FLAC >> $LOG
 patch -p1 < ../01-flac.patch >> $LOG
+patch -p1 < ../02-flac-C-locale.patch >> $LOG
 echo "Configuring..."
 ./configure CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" --with-ogg-includes=$PWD/../libogg-$OGG/include --with-ogg-libraries=$PWD/../libogg-$OGG/src/.libs/ --disable-doxygen-docs --disable-shared --disable-xmms-plugin --disable-dependency-tracking --disable-asm-optimizations --disable-cpplibs --prefix $OUTPUT >> $LOG
 echo "Running make"

--- a/flac/buildme-pcp.sh
+++ b/flac/buildme-pcp.sh
@@ -41,7 +41,8 @@ cd ..
 echo "Cloning FLAC....."
 [ -d flac-$FLAC ] || git clone --depth 1 https://github.com/xiph/flac.git flac-$FLAC >> $LOG
 cd flac-$FLAC >> $LOG
-patch -p1 < ../01-flac.patch
+patch -p1 < ../01-flac.patch >> $LOG
+patch -p1 < ../02-flac-C-locale.patch >> $LOG
 [ -x configure ] || ./autogen.sh >> $LOG
 #. ../../CPAN/update-config.sh
 echo "Configuring..."


### PR DESCRIPTION
This proposed change patches the flac command line tool to force it to work exclusively within the 'C' locale. This ensures that LMS's use of flac's --skip and --until options will work properly in all locales. LMS uses these options when transcoding to seek within a flac format audio file.

The patch applies cleanly to the version of flac 1.32+ adopted by LMS in September 2018, which is taken from the flac tree headed by commit reference faafa4.

Suitable adaptation may be required if another version of flac is used, e.g. the (earlier) published flac version 1.32.

The reasoning behind this patch is discussed in issue #277 filed against Logitech Media Server:
"flac - seeking within files doesn't function in many locales, and breaks playback"
https://github.com/Logitech/slimserver/issues/277

The patch has already been tested on macOS, Debian linux, and at least one version of Windows, and appears to work as expected. 

I have not been able to test all of the build script modifications, as I don't use the platforms, but I can't see what would go wrong here.


I did fall over one point during some earlier testing. If the patch should fail in any of these build scripts, they will just carry on regardless and produce a binary. That was quite puzzling for a while, because I hadn't noticed the failure. Perhaps ```set -e``` or something similar should be placed in the scripts to force a bail out on failure. I don't use these scripts regularly, perhaps someone who does might comment.  
