### PR TITLE
Update to Audio::Scan 1.04 to support MP4 sample rates > 65535.

### DIFF
--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -922,7 +922,7 @@ function build {
             build_module Sub-Uplevel-0.22 "" 0
             build_module Tree-DAG_Node-1.06 "" 0
             build_module Test-Warn-0.23 "" 0
-            build_module Audio-Scan-1.02
+            build_module Audio-Scan-1.04
             ;;
 
         MP3::Cut::Gapless)


### PR DESCRIPTION
Audio::Scan <= 1.02 returns an incorrect byte offset (16-bit overflow) when it calculates a time offset for mp4 files with sample rates greater than 65535.  Discovered and fixed by @philippe44 with commit https://github.com/LMS-Community/Audio-Scan/commit/1043d3d7ee30c204e9c47e8c4bc20b4d9fb4c7f9  and I fixed an issue linking the zlib library for win32 builds. 

The included Audio-Scan-1.04.tar.gz is from https://github.com/LMS-Community/Audio-Scan/releases not Andy Grundman's official repository.