### PR TITLE
Wrong version of libjpeg on FreeBSD

### DIFF
--- a/CPAN/buildme.sh
+++ b/CPAN/buildme.sh
@@ -1245,7 +1245,7 @@ function build_libjpeg {
         $MAKE install
         cd ..
 
-    elif [[ "$ARCH" =~ ^(i[3456]86-linux|x86_64-linux|i86pc-solaris).*$ || "$OS" == "FreeBSD" ]]; then
+    elif [[ "$ARCH" =~ ^(i[3456]86-linux|x86_64-linux|i86pc-solaris).*$ ]]; then
         # build libjpeg-turbo
         tar_wrapper zxf $TURBO_VER.tar.gz
         cd $TURBO_VER


### PR DESCRIPTION
Hi, i have one issue on FreeBSD 12.2 jail ( TrueNAS ) with Perl 5.32.1.
libjpeg-turbo compiles the wrong version for Image Scale.
libjpeg-turbo compiles 6.2 instead of 8.0
libjpeg-turbo/configure :
```
...
checking libjpeg API version... 6.2
checking libjpeg shared library version... 62.2.0
...
```

Image Scale :
```
Image::Scale will be built with:

  JPEG support:     yes (/root/slimserver-vendor/CPAN/build/include, libjpeg version 62)
  PNG support:      yes (/root/slimserver-vendor/CPAN/build/include, libpng version 1.6.37)
  GIF support:      yes (/usr/local/include, giflib version 5.2)
```
```
t/jpeg.t ........... Can't call method "width" on an undefined value at t/jpeg.t line 45.
# Looks like your test exited with 25 before it could output anything.
t/jpeg.t ........... Dubious, test returned 25 (wstat 6400, 0x1900)
Failed 117/117 subtests 

t/stringify.t ...... Image::Scale libjpeg error: Wrong JPEG library version: library is 62, caller expects 80���)
Can't call method "width" on an undefined value at t/stringify.t line 29.
# Looks like your test exited with 25 before it could output anything.
t/stringify.t ...... Dubious, test returned 25 (wstat 6400, 0x1900)
Failed 3/3 subtests 

Test Summary Report
-------------------
t/jpeg.t         (Wstat: 6400 Tests: 0 Failed: 0)
  Non-zero exit status: 25
  Parse errors: Bad plan.  You planned 117 tests but ran 0.
t/stringify.t    (Wstat: 6400 Tests: 0 Failed: 0)
  Non-zero exit status: 25
Parse errors: Bad plan.  You planned 3 tests but ran 0.
Files=9, Tests=96,  1 wallclock secs ( 0.02 usr  0.02 sys +  0.40 cusr  0.13 csys =  0.57 CPU)
Result: FAIL
Failed 2/9 test programs. 0/96 subtests failed.
gmake: *** [Makefile:1049: test_dynamic] Error 25
make test failed, aborting
```