### PR TITLE
Add Raspberry Pi OS ARMv6 CPAN build support

### DIFF
--- a/.github/workflows/buildCPAN.yaml
+++ b/.github/workflows/buildCPAN.yaml
@@ -3,11 +3,12 @@ on:
   workflow_dispatch:
     inputs:
       flavour:
-        description: The Linux flavour we're building for. Currently 'debian' or 'fedora' only.
+        description: The Linux flavour we're building for.
         type: choice
         options:
           - debian
           - fedora
+          - raspbian
           - suse
         required: true
         default: debian
@@ -20,6 +21,7 @@ on:
         type: choice
         options:
           - amd64
+          - arm/v6
           - arm64
           - arm/v7
         required: true
@@ -36,6 +38,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
 
       - name: Set requested Docker image tag
         if: ${{ inputs.tag }}
@@ -57,7 +64,5 @@ jobs:
         uses: actions/upload-artifact@v7
         if: ${{ !env.ACT }}
         with:
-          # TODO - find a way to remove the colons from the module name, and slash from platform
-          # name: ${{ inputs.module && inputs.module || 'CPAN'}}-${{ inputs.flavour }}${{ inputs.tag && format('-{0}', inputs.tag) || ''}}-${{ inputs.platform }}
-          name: CPAN-${{ inputs.flavour }}${{ inputs.tag && format('-{0}', inputs.tag) || ''}}
+          name: CPAN-${{ inputs.flavour }}${{ inputs.tag && format('-{0}', inputs.tag) || ''}}-${{ inputs.platform == 'arm/v6' && 'armv6' || inputs.platform == 'arm/v7' && 'armv7' || inputs.platform }}
           path: CPAN/build/arch/5.*

--- a/CPAN/Docker/Dockerfile.raspbian
+++ b/CPAN/Docker/Dockerfile.raspbian
@@ -1,0 +1,28 @@
+# Build CPAN XS modules for Raspberry Pi OS on ARMv6.
+# Use with Docker/QEMU and --platform=linux/arm/v6.
+FROM balenalib/raspberry-pi-debian:latest
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		binutils \
+		g++ \
+		gcc \
+		libc-bin \
+		libgd-dev \
+		libmodule-install-perl \
+		libtest-warn-perl \
+		make \
+		nasm \
+		patch \
+		perl \
+		rsync \
+		unzip \
+		wget \
+		zlib1g-dev \
+	&& rm -rf /var/lib/apt/lists/*
+
+WORKDIR /cpan
+
+CMD ["/bin/bash"]

--- a/CPAN/Docker/README.md
+++ b/CPAN/Docker/README.md
@@ -25,3 +25,31 @@ docker run --rm --platform=linux/arm/v7 -v `pwd`:/cpan slimservervendor:debian-a
 docker build --rm --platform=linux/arm64/v8 -f "Docker/Dockerfile.debian" -t slimservervendor:debian-arm64 .
 docker run --rm --platform=linux/arm64/v8 -v `pwd`:/cpan slimservervendor:debian-arm64 ./buildme.sh
 ```
+
+## Building for Raspberry Pi OS ARMv6
+
+Use this to build binaries compatible with Raspberry Pi 1 / ARMv6. The
+interactive flags are useful when building or inspecting one module manually.
+
+```
+cd CPAN
+docker build --rm --platform=linux/arm/v6 -f "Docker/Dockerfile.raspbian" -t slimservervendor:raspbian-armv6 .
+docker run --rm -it --platform=linux/arm/v6 -v `pwd`:/cpan -w /cpan slimservervendor:raspbian-armv6 /bin/bash
+```
+
+Inside the container, verify the target and then build the desired module:
+
+```
+perl -MConfig -e 'print "$Config{version} $Config{archname}\n"'
+gcc -Q --help=target | egrep 'march=|mfpu=|mfloat-abi='
+./buildme.sh -t Audio::Scan
+```
+
+For the Github workflow or ACT, use:
+
+```
+flavour: raspbian
+tag: latest
+platform: arm/v6
+module: Audio::Scan
+```


### PR DESCRIPTION
## Raspberry Pi OS / ARMv6 CPAN build support

This PR adds the missing Raspberry Pi OS / ARMv6 build target to `slimserver-vendor`.

The official LMS `.deb` build packages prebuilt CPAN artifacts already present in the `slimserver` repository. This PR alone does not change the next `.deb` automatically. It provides a controlled way to produce replacement artifacts.

## Building Bullseye / Perl 5.32 artifacts

For the Raspberry Pi 1 case, run the vendor workflow twice:

```text
flavour: raspbian
tag: bullseye
platform: arm/v6
module: Audio::Scan
```

```text
flavour: raspbian
tag: bullseye
platform: arm/v6
module: DBD::SQLite
```

Import the resulting `CPAN/build/arch/5.32/arm-linux-gnueabihf-thread-multi-64int` artifacts into `slimserver/CPAN/arch/5.32/arm-linux-gnueabihf-thread-multi-64int` for the official package build.

## Reasons for adding a separate Raspbian target

`Dockerfile.debian`, as currently configured, does not produce Raspberry Pi 1-compatible artifacts:

- The official Debian Bullseye image has no `linux/arm/v6` manifest, so Docker cannot run it with `--platform=linux/arm/v6`.
- Running `Dockerfile.debian` with `--platform=linux/arm/v7` is not an ARMv6 substitute. In an ARMv7 Debian container, GCC defaults to `-march=armv7-a+fp` and `-mfpu=vfpv3-d16`. Those instructions are not supported by a Pi 1.
- On Raspberry Pi OS Bullseye with `--platform=linux/arm/v6`, GCC defaults to `-march=armv6+fp` and `-mfpu=vfp`, which is the required Pi 1 baseline.

A Debian ARMv7 build could potentially be made Pi 1-compatible by explicitly applying ARMv6 compiler flags consistently to every native build. That would be a separate build-script change. The Raspbian target provides those defaults directly.

The Raspberry Pi OS ARMv6 and Debian ARMv7 environments both report the same Perl archname, `arm-linux-gnueabihf-thread-multi-64int`. That name describes the Perl ABI, not the CPU instruction baseline of the XS shared objects, so it cannot distinguish an ARMv7 artifact from a Pi 1-compatible one.

## Why did it work before version 9.10?

The previously working Perl 5.32 ARM `DBD::SQLite` artifact was added to `slimserver` on 2021-01-03 ([`74febd721`](https://github.com/LMS-Community/slimserver/commit/74febd7210628f42defbeead69991faabeb02cc3)). `Dockerfile.debian` was only introduced in `slimserver-vendor` on 2022-02-08 ([`c237aa6`](https://github.com/LMS-Community/slimserver-vendor/commit/c237aa6)). Thus the known-good artifact cannot have been produced with `Dockerfile.debian`; it was built differently. The 2025 `DBD::SQLite` replacement ([`ba0efae2`](https://github.com/LMS-Community/slimserver/commit/ba0efae2ee67b401fc7b5fbf14c6eeaacd62d236), explicitly labelled ARMv7) is the binary change between working LMS 9.0.3 and failing LMS 9.1.0.

## Newer Raspbian targets

For newer Raspberry Pi OS targets, we could run the Raspbian workflow with `tag: bookworm` (Perl 5.36) and `tag: sid` (Perl 5.40). This produces ARMv6 artifacts for those Perl versions as well.

The existing Debian workflow remains appropriate for ARMv7 hardware. Those artifacts should not be substituted for the Raspbian ARMv6 output.
